### PR TITLE
Add seed script for initial administrator user

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,18 @@ El sistema contempla tres roles de usuario:
    cd ../frontend
    npm install
    ```
-4. Registra el primer usuario mediante `POST /api/auth/register` (sin cabecera `Authorization`).
-   Ese usuario será administrador automáticamente. Para crear cuentas adicionales envía el token
-   JWT de un admin en la cabecera `Authorization: Bearer <token>`.
+4. Crea el primer usuario de alguna de estas formas:
+   - Ejecuta el seed incluido en el backend:
+     ```bash
+     cd backend
+     npm run seed
+     ```
+     Esto generará un administrador por defecto (`admin@bodega.com` / `Admin123!`).
+     Puedes personalizar nombre, correo y contraseña exportando las variables de entorno
+     `SEED_ADMIN_NAME`, `SEED_ADMIN_EMAIL` y `SEED_ADMIN_PASSWORD` antes de ejecutar el comando.
+   - O bien realiza una petición `POST /api/auth/register` (sin cabecera `Authorization`). Ese
+     primer usuario será administrador automáticamente. Para crear cuentas adicionales envía el
+     token JWT de un admin en la cabecera `Authorization: Bearer <token>`.
 5. Ejecutar los servicios en terminales separadas:
    ```bash
    # Backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
+    "seed": "node src/seed.js",
     "test": "echo \"No hay pruebas configuradas\""
   },
   "keywords": [],

--- a/backend/src/seed.js
+++ b/backend/src/seed.js
@@ -1,0 +1,59 @@
+const dotenv = require('dotenv');
+const mongoose = require('mongoose');
+const User = require('./models/User');
+const { hashPassword } = require('./utils/password');
+
+dotenv.config();
+
+const DEFAULT_NAME = 'Administrador';
+const DEFAULT_EMAIL = 'admin@bodega.com';
+const DEFAULT_PASSWORD = 'Admin123!';
+
+const name = process.env.SEED_ADMIN_NAME || DEFAULT_NAME;
+const email = (process.env.SEED_ADMIN_EMAIL || DEFAULT_EMAIL).toLowerCase();
+const password = process.env.SEED_ADMIN_PASSWORD || DEFAULT_PASSWORD;
+const role = 'ADMIN';
+
+const MONGODB_URI =
+  process.env.MONGODB_URI ||
+  'mongodb+srv://ERPCHA>:ERPCHA@basededatos1.hwq53bl.mongodb.net/?retryWrites=true&w=majority&appName=Basededatos1';
+
+async function main() {
+  try {
+    console.log('Connecting to MongoDB...');
+    await mongoose.connect(MONGODB_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log('MongoDB connection established');
+
+    const existingUser = await User.findOne({ email });
+    if (existingUser) {
+      console.log('A user with this email already exists. Skipping creation.');
+      return;
+    }
+
+    const passwordHash = hashPassword(password);
+
+    const user = await User.create({
+      name,
+      email,
+      passwordHash,
+      role,
+    });
+
+    console.log('Usuario administrador creado exitosamente:');
+    console.log(`  Nombre: ${user.name}`);
+    console.log(`  Correo: ${user.email}`);
+    console.log(`  Contraseña: ${password}`);
+    console.log('¡Recuerda actualizar la contraseña después de iniciar sesión!');
+  } catch (error) {
+    console.error('Error al crear el usuario administrador:', error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+    console.log('Conexión a MongoDB cerrada');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a dedicated seed script that connects to MongoDB and provisions a default admin user
- expose the script via `npm run seed` and document its usage and environment overrides in the README

## Testing
- npm --prefix backend run test

------
https://chatgpt.com/codex/tasks/task_b_68d34ad2e6788321b38937ee5bfffc87