### PR TITLE
feat(frontend): aplicar estética inspirada en ChileAtiende

### DIFF
--- a/frontend/src/assets/chileatiende-logo.svg
+++ b/frontend/src/assets/chileatiende-logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 72" role="img" aria-labelledby="title desc">
+  <title id="title">ChileAtiende Marca</title>
+  <desc id="desc">Logotipo estilizado inspirado en ChileAtiende con bloque rojo y texto azul.</desc>
+  <rect width="72" height="72" rx="8" fill="#e1262f"/>
+  <circle cx="36" cy="24" r="11" fill="#ffffff"/>
+  <path d="M21 54c0-9.94 6.06-18 15-18s15 8.06 15 18" fill="#ffffff"/>
+  <path d="M29 56h14c3 0 5.5 2.5 5.5 5.5V68H23.5v-6.5C23.5 58.5 26 56 29 56z" fill="#003b70" opacity="0.35"/>
+  <g fill="#003b70" font-family="'Montserrat','Segoe UI',sans-serif" font-size="28" font-weight="600">
+    <text x="88" y="36">Chile</text>
+    <text x="88" y="60">Atiende</text>
+  </g>
+  <line x1="88" y1="42" x2="214" y2="42" stroke="#e1262f" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+</svg>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -6,6 +6,7 @@ import ProductForm from '../components/ProductForm';
 import ProductTable from '../components/ProductTable';
 import { getApiUrl } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
+import brandLogo from '../assets/chileatiende-logo.svg';
 
 function Dashboard() {
   const { user, token, logout, hasRole, request } = useAuth();
@@ -29,6 +30,16 @@ function Dashboard() {
   const selectedProduct = useMemo(
     () => products.find((product) => product._id === selectedProductId) || null,
     [products, selectedProductId]
+  );
+
+  const availableProducts = useMemo(
+    () => products.filter((product) => !product.currentAssignment).length,
+    [products]
+  );
+
+  const assignedProducts = useMemo(
+    () => products.length - availableProducts,
+    [products, availableProducts]
   );
 
   const loadProducts = useCallback(async () => {
@@ -220,15 +231,22 @@ function Dashboard() {
     [token]
   );
 
+  const welcomeMessage = canManage
+    ? 'Administra el inventario y garantiza la continuidad del servicio.'
+    : 'Consulta el inventario disponible y revisa los movimientos de los equipos.';
+
   return (
     <div className="dashboard">
-      <header className="dashboard-header">
-        <div>
-          <h1>Bienvenido, {user.name}</h1>
-          <p className="muted">Rol: {user.role}</p>
+      <header className="dashboard-topbar">
+        <div className="dashboard-topbar__brand">
+          <img src={brandLogo} alt="ChileAtiende" className="dashboard-topbar__logo" />
+          <div>
+            <p className="brand-title">ChileAtiende</p>
+            <p className="brand-subtitle">Administración de Bodega</p>
+          </div>
         </div>
-        <div className="header-actions">
-          <button type="button" className="secondary" onClick={loadProducts} disabled={loadingProducts}>
+        <div className="topbar-actions">
+          <button type="button" className="ghost" onClick={loadProducts} disabled={loadingProducts}>
             {loadingProducts ? 'Actualizando...' : 'Actualizar stock'}
           </button>
           <button type="button" className="logout" onClick={logout}>
@@ -237,14 +255,43 @@ function Dashboard() {
         </div>
       </header>
 
+      <section className="dashboard-hero">
+        <div className="dashboard-hero__message">
+          <h1>Hola, {user.name}</h1>
+          <p>{welcomeMessage}</p>
+          <span className="hero-pill">Rol: {user.role}</span>
+        </div>
+        <div className="dashboard-hero__stats">
+          <div className="hero-stat">
+            <span>Productos totales</span>
+            <strong>{products.length}</strong>
+          </div>
+          <div className="hero-stat">
+            <span>Disponibles</span>
+            <strong>{availableProducts}</strong>
+          </div>
+          <div className="hero-stat">
+            <span>Asignados</span>
+            <strong>{assignedProducts}</strong>
+          </div>
+          {selectedProduct && (
+            <div className="hero-stat highlight">
+              <span>Producto seleccionado</span>
+              <strong>{selectedProduct.name}</strong>
+              <small>{selectedProduct.serialNumber || 'Sin número de serie'}</small>
+            </div>
+          )}
+        </div>
+      </section>
+
       {productsError && (
-        <div className="card">
+        <div className="alert alert-error" role="alert">
           <strong>Error:</strong> {productsError}
         </div>
       )}
 
       {adError && canManage && (
-        <div className="card">
+        <div className="alert alert-warning" role="status">
           <strong>Advertencia:</strong> {adError}
         </div>
       )}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import brandLogo from '../assets/chileatiende-logo.svg';
 
 function LoginPage() {
   const navigate = useNavigate();
@@ -32,39 +33,77 @@ function LoginPage() {
   };
 
   return (
-    <div className="auth-layout">
-      <form className="card" onSubmit={handleSubmit}>
-        <h1>Administración de Bodega</h1>
-        <p className="muted">Ingresa con tu correo corporativo y contraseña.</p>
-        <label>
-          Correo electrónico
-          <input
-            type="email"
-            name="email"
-            value={formValues.email}
-            onChange={handleChange}
-            required
-          />
-        </label>
-        <label>
-          Contraseña
-          <input
-            type="password"
-            name="password"
-            value={formValues.password}
-            onChange={handleChange}
-            required
-          />
-        </label>
-        {error && <p className="error">{error}</p>}
-        <button type="submit" disabled={loading}>
-          {loading ? 'Ingresando...' : 'Ingresar'}
-        </button>
-        <p className="muted small-text">
-          Si es la primera vez que utilizas el sistema solicita a un administrador que cree tu
-          cuenta o ejecuta el script de aprovisionamiento.
-        </p>
-      </form>
+    <div className="auth-page">
+      <section className="auth-hero">
+        <div className="auth-hero__brand">
+          <img src={brandLogo} alt="ChileAtiende" />
+          <span>Red de Atención a la Ciudadanía</span>
+        </div>
+        <div className="auth-hero__content">
+          <h1>Gestión de Bodega ChileAtiende</h1>
+          <p>
+            Integra el control de inventario con la cercanía y transparencia del servicio
+            ChileAtiende. Centraliza la información de equipos críticos y facilita la atención a
+            funcionarias y funcionarios.
+          </p>
+          <ul className="auth-hero__list">
+            <li>Inventario actualizado y trazable en todo momento.</li>
+            <li>Asignaciones y devoluciones con respaldo documental.</li>
+            <li>Experiencia de uso alineada a la identidad institucional.</li>
+          </ul>
+        </div>
+        <div className="auth-hero__footer">
+          <span>Ministerio de Desarrollo Social y Familia</span>
+        </div>
+      </section>
+
+      <section className="auth-content">
+        <form className="card auth-form" onSubmit={handleSubmit}>
+          <div className="auth-form__header">
+            <img src={brandLogo} alt="Logotipo ChileAtiende" className="auth-form__logo" />
+            <h2>Inicia sesión</h2>
+            <p className="muted">Ingresa con tu correo corporativo y contraseña.</p>
+          </div>
+
+          <label>
+            Correo electrónico
+            <input
+              type="email"
+              name="email"
+              value={formValues.email}
+              onChange={handleChange}
+              placeholder="nombre@institucion.cl"
+              required
+            />
+          </label>
+          <label>
+            Contraseña
+            <input
+              type="password"
+              name="password"
+              value={formValues.password}
+              onChange={handleChange}
+              placeholder="Ingresa tu clave"
+              required
+            />
+          </label>
+
+          {error && (
+            <p className="alert alert-error" role="alert">
+              {error}
+            </p>
+          )}
+
+          <button type="submit" className="primary" disabled={loading}>
+            {loading ? 'Ingresando...' : 'Ingresar al sistema'}
+          </button>
+
+          <p className="muted small-text auth-form__support">
+            ¿Necesitas ayuda? Contáctanos mediante la mesa de servicios institucional o revisa el
+            manual rápido de la plataforma.
+          </p>
+        </form>
+      </section>
     </div>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,8 +1,20 @@
 :root {
   color-scheme: light;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f6f7fb;
-  color: #111827;
+  font-family: 'Montserrat', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --color-blue-900: #003b70;
+  --color-blue-700: #005aa7;
+  --color-blue-500: #0d7ac7;
+  --color-blue-400: #3fa9f5;
+  --color-red-500: #e1262f;
+  --color-red-400: #ff4d64;
+  --color-neutral-100: #f5f7fb;
+  --color-neutral-200: #eef3fb;
+  --color-neutral-300: #dfe6f4;
+  --color-neutral-400: #bcc7d9;
+  --color-neutral-500: #6c7a89;
+  --color-neutral-700: #2f3a4a;
+  background-color: var(--color-neutral-100);
+  color: var(--color-neutral-700);
 }
 
 * {
@@ -12,43 +24,181 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, #f6f7fb 0%, #e8ebf5 100%);
+  background: radial-gradient(circle at 10% 20%, rgba(225, 240, 255, 0.65) 0%, rgba(244, 248, 255, 0) 55%),
+    radial-gradient(circle at 90% 10%, rgba(255, 230, 236, 0.7) 0%, rgba(255, 240, 244, 0) 60%),
+    linear-gradient(180deg, var(--color-neutral-100) 0%, #eef1f8 100%);
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
-.auth-layout {
+a:hover {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.auth-page {
   min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  background: transparent;
+}
+
+.auth-hero {
+  background: linear-gradient(135deg, var(--color-blue-700) 0%, var(--color-blue-500) 45%, var(--color-blue-400) 100%);
+  color: #ffffff;
+  padding: 3.5rem clamp(2rem, 5vw, 4.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.auth-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18) 0%, transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(225, 38, 47, 0.2) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.auth-hero__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--color-blue-900);
+  box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.6);
+  position: relative;
+  z-index: 1;
+}
+
+.auth-hero__brand img {
+  width: 132px;
+}
+
+.auth-hero__brand span {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.auth-hero__content {
+  max-width: 520px;
+  position: relative;
+  z-index: 1;
+}
+
+.auth-hero__content h1 {
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  margin: 0 0 1rem;
+  line-height: 1.2;
+}
+
+.auth-hero__content p {
+  margin: 0 0 1.25rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.auth-hero__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.auth-hero__list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.auth-hero__list li::before {
+  content: '•';
+  font-size: 1.2rem;
+  line-height: 1;
+  margin-top: 0.15rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.auth-hero__footer {
+  margin-top: auto;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+  position: relative;
+  z-index: 1;
+}
+
+.auth-content {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: clamp(2.5rem, 6vw, 4rem);
 }
 
 .card {
   background: #ffffff;
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.35);
+  border-radius: 20px;
+  padding: 1.75rem;
+  border: 1px solid var(--color-neutral-300);
+  box-shadow: 0 24px 60px -40px rgba(15, 23, 42, 0.45);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
+  position: relative;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  border-top: 4px solid rgba(225, 38, 47, 0.75);
+  pointer-events: none;
 }
 
 .card-header h2,
 .card-header h3 {
   margin: 0;
+  color: var(--color-blue-900);
 }
 
 .card-header p {
-  margin: 0.25rem 0 0;
+  margin: 0.35rem 0 0;
 }
 
-form.card {
-  max-width: 420px;
-  width: 100%;
+.auth-form {
+  width: min(420px, 100%);
+}
+
+.auth-form__header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.auth-form__logo {
+  width: 160px;
 }
 
 label {
@@ -56,7 +206,7 @@ label {
   flex-direction: column;
   gap: 0.5rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-blue-900);
 }
 
 input,
@@ -69,83 +219,261 @@ button {
 input,
 select,
 textarea {
-  padding: 0.65rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid #d0d6e6;
-  background-color: #f9fafb;
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-neutral-300);
+  background-color: #ffffff;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  color: inherit;
 }
 
 input:focus,
 select:focus,
 textarea:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  border-color: var(--color-blue-500);
+  box-shadow: 0 0 0 3px rgba(13, 122, 199, 0.18);
+}
+
+textarea {
+  resize: vertical;
 }
 
 button {
   border: none;
-  border-radius: 12px;
-  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
   font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 button.primary {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  background: linear-gradient(135deg, var(--color-red-500), var(--color-red-400));
   color: #ffffff;
-  box-shadow: 0 12px 24px -16px rgba(37, 99, 235, 0.8);
+  box-shadow: 0 14px 36px -22px rgba(225, 38, 47, 0.85);
 }
 
-button.secondary {
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px -20px rgba(225, 38, 47, 0.75);
+}
+
+button.secondary,
+button.ghost {
   background: #ffffff;
-  border: 1px solid #cbd5f5;
-  color: #1d4ed8;
+  border: 1px solid var(--color-blue-500);
+  color: var(--color-blue-700);
+  box-shadow: 0 12px 24px -24px rgba(13, 122, 199, 0.6);
+}
+
+button.secondary:hover,
+button.ghost:hover {
+  background: rgba(13, 122, 199, 0.08);
 }
 
 button.link {
   background: none;
-  color: #2563eb;
+  color: var(--color-blue-700);
   padding: 0;
   border-radius: 0;
+  border: none;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+button.logout {
+  background: none;
+  border: 1px solid transparent;
+  color: var(--color-red-500);
+  font-weight: 700;
+}
+
+button.logout:hover {
+  color: #b81e28;
 }
 
 button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  transform: none;
 }
 
 small,
 .muted {
-  color: #6b7280;
+  color: var(--color-neutral-500);
   font-weight: 400;
 }
 
 .small-text {
   font-size: 0.85rem;
+  line-height: 1.4;
 }
 
-.error {
-  color: #dc2626;
-  font-weight: 600;
+.auth-form button {
+  width: 100%;
+}
+
+.auth-form__support {
+  text-align: center;
+}
+
+.alert {
+  border-radius: 16px;
+  padding: 0.85rem 1.1rem;
+  border: 1px solid transparent;
+  font-weight: 500;
+}
+
+.alert-error {
+  background: rgba(225, 38, 47, 0.08);
+  border-color: rgba(225, 38, 47, 0.35);
+  color: #a1111c;
+}
+
+.alert-warning {
+  background: rgba(255, 177, 66, 0.18);
+  border-color: rgba(229, 146, 0, 0.35);
+  color: #a05a00;
 }
 
 .dashboard {
-  padding: 2rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
   max-width: 1200px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
-.dashboard-header {
+.dashboard-topbar {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 1.25rem clamp(1.5rem, 3vw, 2.5rem);
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
+  box-shadow: 0 28px 60px -42px rgba(15, 23, 42, 0.45);
+  border-bottom: 4px solid rgba(225, 38, 47, 0.75);
+}
+
+.dashboard-topbar__brand {
+  display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+.dashboard-topbar__logo {
+  width: 148px;
+}
+
+.brand-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-blue-900);
+}
+
+.brand-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-neutral-500);
+}
+
+.topbar-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.dashboard-hero {
+  background: linear-gradient(135deg, var(--color-blue-700) 0%, var(--color-blue-500) 60%, var(--color-blue-400) 100%);
+  color: #ffffff;
+  border-radius: 28px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: stretch;
+  box-shadow: 0 32px 70px -40px rgba(0, 59, 112, 0.6);
+}
+
+.dashboard-hero__message {
+  flex: 1 1 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dashboard-hero__message h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.dashboard-hero__message p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.hero-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.12);
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+.dashboard-hero__stats {
+  flex: 1 1 320px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.hero-stat {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 120px;
+  box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.45);
+}
+
+.hero-stat span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.hero-stat strong {
+  font-size: 2rem;
+  line-height: 1.2;
+}
+
+.hero-stat small {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero-stat.highlight {
+  background: rgba(255, 255, 255, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.55);
 }
 
 .dashboard-grid {
@@ -168,46 +496,61 @@ small,
   font-size: 0.95rem;
 }
 
-.data-table th,
-.data-table td {
-  padding: 0.75rem;
-  text-align: left;
-  border-bottom: 1px solid #e2e8f0;
+.data-table thead {
+  background: rgba(13, 122, 199, 0.08);
 }
 
-.data-table tr:hover {
-  background-color: #f1f5f9;
+.data-table th {
+  padding: 0.85rem;
+  text-align: left;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-blue-900);
+  border-bottom: 2px solid rgba(13, 122, 199, 0.25);
+}
+
+.data-table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--color-neutral-300);
+  color: inherit;
+}
+
+.data-table tbody tr:hover {
+  background-color: rgba(13, 122, 199, 0.08);
 }
 
 .data-table tr.selected {
-  background-color: rgba(37, 99, 235, 0.12);
+  background-color: rgba(225, 38, 47, 0.12);
 }
 
 .data-table.compact th,
 .data-table.compact td {
-  padding: 0.5rem;
+  padding: 0.55rem 0.65rem;
 }
 
 .status {
-  padding: 0.25rem 0.5rem;
+  padding: 0.3rem 0.6rem;
   border-radius: 999px;
   font-size: 0.75rem;
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .status.success {
-  background: #ecfdf3;
-  color: #166534;
+  background: rgba(28, 204, 120, 0.12);
+  color: #117d51;
 }
 
 .status.info {
-  background: #eef2ff;
-  color: #3730a3;
+  background: rgba(13, 122, 199, 0.15);
+  color: var(--color-blue-700);
 }
 
 .status.warning {
-  background: #fff7ed;
-  color: #b45309;
+  background: rgba(255, 177, 66, 0.2);
+  color: #a05a00;
 }
 
 .form-grid {
@@ -219,6 +562,8 @@ small,
 .form-grid .actions {
   display: flex;
   gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .form-grid .full-width {
@@ -232,9 +577,9 @@ small,
 }
 
 .assignment-section {
-  background: #f8fafc;
-  padding: 1rem;
-  border-radius: 12px;
+  background: rgba(13, 122, 199, 0.08);
+  padding: 1.1rem;
+  border-radius: 16px;
 }
 
 .assignment-box {
@@ -243,8 +588,8 @@ small,
   gap: 0.5rem;
   background: #ffffff;
   padding: 1rem;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  border: 1px solid var(--color-neutral-300);
 }
 
 .header-actions {
@@ -254,17 +599,61 @@ small,
 }
 
 .logout {
-  background: none;
-  border: none;
-  color: #ef4444;
+  color: var(--color-red-500);
 }
 
-@media (max-width: 960px) {
+@media (max-width: 1100px) {
   .dashboard-grid {
     grid-template-columns: 1fr;
   }
 
   .dashboard-grid.secondary {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 960px) {
+  .auth-page {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-hero {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    padding: 2.5rem;
+  }
+
+  .auth-content {
+    padding: 2.5rem;
+  }
+
+  .dashboard-topbar,
+  .dashboard-hero {
+    border-radius: 20px;
+  }
+}
+
+@media (max-width: 640px) {
+  .auth-hero__brand {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard-topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .topbar-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .dashboard-hero {
+    flex-direction: column;
+  }
+
+  .dashboard-hero__stats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- rediseñé el inicio de sesión y el dashboard con una estética inspirada en ChileAtiende, incorporando el logotipo institucional
- actualicé los estilos globales para reflejar la paleta azul y roja, nuevas tarjetas, alertas y componentes hero con métricas
- añadí un recurso SVG con la marca ChileAtiende para reutilizarlo en la interfaz

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d34f1f5d888321903e7ca957d0d3b1