### PR TITLE
Split dashboard flows and add product lifecycle management

### DIFF
--- a/backend/src/models/Product.js
+++ b/backend/src/models/Product.js
@@ -26,7 +26,15 @@ const productSchema = new Schema(
     inventoryNumber: { type: String, trim: true },
     rentalId: { type: String, trim: true },
     dispatchGuide: { type: Schema.Types.ObjectId, ref: 'DispatchGuide', required: true },
+    status: {
+      type: String,
+      enum: ['AVAILABLE', 'ASSIGNED', 'DECOMMISSIONED'],
+      default: 'AVAILABLE',
+    },
     currentAssignment: assignmentSnapshotSchema,
+    decommissionReason: { type: String, trim: true },
+    decommissionedAt: { type: Date },
+    decommissionedBy: { type: Schema.Types.ObjectId, ref: 'User' },
     createdBy: { type: Schema.Types.ObjectId, ref: 'User' },
   },
   { timestamps: true }

--- a/backend/src/routes/dispatchGuideRoutes.js
+++ b/backend/src/routes/dispatchGuideRoutes.js
@@ -52,4 +52,11 @@ router.get(
   dispatchGuideController.downloadDispatchGuide
 );
 
+router.delete(
+  '/:id',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  dispatchGuideController.deleteDispatchGuide
+);
+
 module.exports = router;

--- a/backend/src/routes/productRoutes.js
+++ b/backend/src/routes/productRoutes.js
@@ -41,4 +41,18 @@ router.get(
   productController.getAssignmentHistory
 );
 
+router.post(
+  '/:id/decommission',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  productController.decommissionProduct
+);
+
+router.delete(
+  '/:id',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  productController.deleteProduct
+);
+
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,11 @@ import ProtectedRoute from './components/ProtectedRoute';
 import { useAuth } from './hooks/useAuth';
 import LoginPage from './pages/LoginPage';
 import Dashboard from './pages/Dashboard';
+import InventoryPage from './pages/InventoryPage';
+import AssignmentsPage from './pages/AssignmentsPage';
+import ProductEntryPage from './pages/ProductEntryPage';
+import DispatchGuidesPage from './pages/DispatchGuidesPage';
+import ProductDecommissionPage from './pages/ProductDecommissionPage';
 
 function App() {
   const { isAuthenticated } = useAuth();
@@ -20,7 +25,13 @@ function App() {
             <Dashboard />
           </ProtectedRoute>
         }
-      />
+      >
+        <Route index element={<InventoryPage />} />
+        <Route path="asignaciones" element={<AssignmentsPage />} />
+        <Route path="productos/nuevo" element={<ProductEntryPage />} />
+        <Route path="guias" element={<DispatchGuidesPage />} />
+        <Route path="bajas" element={<ProductDecommissionPage />} />
+      </Route>
       <Route
         path="*"
         element={<Navigate to={isAuthenticated ? '/' : '/login'} replace />}

--- a/frontend/src/components/AssignmentHistory.jsx
+++ b/frontend/src/components/AssignmentHistory.jsx
@@ -14,19 +14,20 @@ function AssignmentHistory({ history, loading }) {
               <th>Ubicación</th>
               <th>Fecha</th>
               <th>Registrado por</th>
+              <th>Notas</th>
             </tr>
           </thead>
           <tbody>
             {loading && (
               <tr>
-                <td colSpan={6} className="muted">
+                <td colSpan={7} className="muted">
                   Cargando movimientos...
                 </td>
               </tr>
             )}
             {!loading && history.length === 0 && (
               <tr>
-                <td colSpan={6} className="muted">
+                <td colSpan={7} className="muted">
                   No hay movimientos registrados.
                 </td>
               </tr>
@@ -35,7 +36,7 @@ function AssignmentHistory({ history, loading }) {
               <tr key={item._id}>
                 <td>
                   <span className={item.action === 'ASSIGN' ? 'status info' : 'status warning'}>
-                    {item.action === 'ASSIGN' ? 'Asignación' : 'Desasignación'}
+                    {item.action === 'ASSIGN' ? 'Asignación' : 'Liberación'}
                   </span>
                 </td>
                 <td>{item.assignedTo}</td>
@@ -43,6 +44,7 @@ function AssignmentHistory({ history, loading }) {
                 <td>{item.location}</td>
                 <td>{new Date(item.assignmentDate).toLocaleString('es-CL')}</td>
                 <td>{item.performedBy?.name || '—'}</td>
+                <td>{item.notes || '—'}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/components/DispatchGuideManager.jsx
+++ b/frontend/src/components/DispatchGuideManager.jsx
@@ -6,7 +6,7 @@ const initialState = {
   dispatchDate: '',
 };
 
-function DispatchGuideManager({ guides, onUpload, onRefresh, onDownload, isUploading }) {
+function DispatchGuideManager({ guides, onUpload, onRefresh, onDownload, onDelete, isUploading }) {
   const [values, setValues] = useState(initialState);
   const [error, setError] = useState('');
   const fileInputRef = useRef(null);
@@ -93,12 +93,13 @@ function DispatchGuideManager({ guides, onUpload, onRefresh, onDownload, isUploa
               <th>Proveedor</th>
               <th>Fecha</th>
               <th>Archivo</th>
+              <th>Acciones</th>
             </tr>
           </thead>
           <tbody>
             {guides.length === 0 && (
               <tr>
-                <td colSpan={4} className="muted">
+                <td colSpan={5} className="muted">
                   No hay guías cargadas.
                 </td>
               </tr>
@@ -111,6 +112,15 @@ function DispatchGuideManager({ guides, onUpload, onRefresh, onDownload, isUploa
                 <td>
                   <button type="button" className="link" onClick={() => onDownload(guide)}>
                     Descargar
+                  </button>
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    className="danger compact"
+                    onClick={() => onDelete(guide)}
+                  >
+                    Eliminar
                   </button>
                 </td>
               </tr>
@@ -126,6 +136,7 @@ DispatchGuideManager.defaultProps = {
   guides: [],
   onRefresh: () => {},
   onDownload: () => {},
+  onDelete: () => {},
   isUploading: false,
 };
 

--- a/frontend/src/components/ProductTable.jsx
+++ b/frontend/src/components/ProductTable.jsx
@@ -1,3 +1,5 @@
+import { getProductStatusBadge, getProductStatusLabel } from '../utils/productStatus';
+
 function formatType(type) {
   if (type === 'PURCHASED') {
     return 'Compra';
@@ -25,6 +27,7 @@ function ProductTable({ products, onSelect, selectedProductId }) {
               <th>N° parte</th>
               <th>Inventario / ID</th>
               <th>Guía</th>
+              <th>Estado</th>
               <th>Asignación actual</th>
             </tr>
           </thead>
@@ -55,13 +58,23 @@ function ProductTable({ products, onSelect, selectedProductId }) {
                   </td>
                   <td>{product.dispatchGuide?.guideNumber || '—'}</td>
                   <td>
-                    {product.currentAssignment ? (
+                    <span className={getProductStatusBadge(product.status)}>
+                      {getProductStatusLabel(product.status)}
+                    </span>
+                    {product.status === 'DECOMMISSIONED' && product.decommissionReason && (
+                      <div className="muted small-text">{product.decommissionReason}</div>
+                    )}
+                  </td>
+                  <td>
+                    {product.status === 'ASSIGNED' && product.currentAssignment ? (
                       <span>
                         {product.currentAssignment.assignedTo}{' '}
                         <span className="muted">({product.currentAssignment.location})</span>
                       </span>
+                    ) : product.status === 'DECOMMISSIONED' ? (
+                      <span className="muted">No disponible</span>
                     ) : (
-                      <span className="status success">Disponible</span>
+                      <span className="muted">Sin asignación</span>
                     )}
                   </td>
                 </tr>

--- a/frontend/src/pages/AssignmentsPage.jsx
+++ b/frontend/src/pages/AssignmentsPage.jsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import ProductTable from '../components/ProductTable';
+import ProductAssignmentPanel from '../components/ProductAssignmentPanel';
+import AssignmentHistory from '../components/AssignmentHistory';
+import { useAuth } from '../hooks/useAuth';
+
+function AssignmentsPage() {
+  const { request, hasRole } = useAuth();
+  const [products, setProducts] = useState([]);
+  const [productsError, setProductsError] = useState('');
+  const [loadingProducts, setLoadingProducts] = useState(false);
+  const [selectedProductId, setSelectedProductId] = useState(null);
+  const [assignmentHistory, setAssignmentHistory] = useState([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [assignmentProcessing, setAssignmentProcessing] = useState(false);
+  const [adUsers, setAdUsers] = useState([]);
+  const [adError, setAdError] = useState('');
+
+  const canManage = hasRole('ADMIN', 'MANAGER');
+
+  const loadProducts = useCallback(async () => {
+    setLoadingProducts(true);
+    setProductsError('');
+    try {
+      const data = await request('/products?status=AVAILABLE,ASSIGNED');
+      setProducts(data);
+      setSelectedProductId((current) => {
+        if (!data.length) {
+          return null;
+        }
+        if (current && data.some((item) => item._id === current)) {
+          return current;
+        }
+        return data[0]._id;
+      });
+    } catch (error) {
+      setProductsError(error.message || 'No se pudo obtener el inventario disponible.');
+    } finally {
+      setLoadingProducts(false);
+    }
+  }, [request]);
+
+  const loadAssignmentHistory = useCallback(
+    async (productId) => {
+      if (!productId) {
+        setAssignmentHistory([]);
+        return;
+      }
+      setHistoryLoading(true);
+      try {
+        const history = await request(`/products/${productId}/assignments`);
+        setAssignmentHistory(history);
+      } catch (error) {
+        setAssignmentHistory([]);
+      } finally {
+        setHistoryLoading(false);
+      }
+    },
+    [request]
+  );
+
+  const loadAdUsers = useCallback(async () => {
+    if (!canManage) {
+      setAdUsers([]);
+      return;
+    }
+    try {
+      const users = await request('/ad/users');
+      setAdUsers(users);
+      setAdError('');
+    } catch (error) {
+      setAdError('No se pudieron sincronizar los usuarios de Active Directory.');
+      setAdUsers([]);
+    }
+  }, [canManage, request]);
+
+  useEffect(() => {
+    if (canManage) {
+      loadProducts();
+      loadAdUsers();
+    }
+  }, [loadProducts, loadAdUsers, canManage]);
+
+  useEffect(() => {
+    if (selectedProductId && canManage) {
+      loadAssignmentHistory(selectedProductId);
+    } else {
+      setAssignmentHistory([]);
+    }
+  }, [selectedProductId, loadAssignmentHistory, canManage]);
+
+  const selectedProduct = useMemo(
+    () => products.find((product) => product._id === selectedProductId) || null,
+    [products, selectedProductId]
+  );
+
+  const handleAssignProduct = useCallback(
+    async (payload) => {
+      if (!selectedProductId) {
+        return;
+      }
+      const targetId = selectedProductId;
+      setAssignmentProcessing(true);
+      try {
+        await request(`/products/${targetId}/assign`, {
+          method: 'POST',
+          data: payload,
+        });
+        await loadProducts();
+        await loadAssignmentHistory(targetId);
+      } finally {
+        setAssignmentProcessing(false);
+      }
+    },
+    [request, selectedProductId, loadProducts, loadAssignmentHistory]
+  );
+
+  const handleUnassignProduct = useCallback(
+    async (payload) => {
+      if (!selectedProductId) {
+        return;
+      }
+      const targetId = selectedProductId;
+      setAssignmentProcessing(true);
+      try {
+        await request(`/products/${targetId}/unassign`, {
+          method: 'POST',
+          data: payload,
+        });
+        await loadProducts();
+        await loadAssignmentHistory(targetId);
+      } finally {
+        setAssignmentProcessing(false);
+      }
+    },
+    [request, selectedProductId, loadProducts, loadAssignmentHistory]
+  );
+
+  if (!canManage) {
+    return (
+      <section className="dashboard-section">
+        <div className="card">
+          <h2>Asignaciones</h2>
+          <p className="muted">
+            Debes tener permisos de administrador o encargado para gestionar asignaciones.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Asignaciones</h2>
+          <p className="muted">Gestiona la entrega y liberación de equipos.</p>
+        </div>
+        <div className="section-actions">
+          <button
+            type="button"
+            className="secondary"
+            onClick={loadProducts}
+            disabled={loadingProducts}
+          >
+            {loadingProducts ? 'Actualizando...' : 'Actualizar listado'}
+          </button>
+        </div>
+      </div>
+
+      {productsError && (
+        <div className="card">
+          <strong>Error:</strong> {productsError}
+        </div>
+      )}
+
+      {adError && (
+        <div className="card">
+          <strong>Advertencia:</strong> {adError}
+        </div>
+      )}
+
+      <div className="dashboard-grid">
+        <ProductTable
+          products={products}
+          onSelect={setSelectedProductId}
+          selectedProductId={selectedProductId}
+        />
+        <div className="stack">
+          <ProductAssignmentPanel
+            product={selectedProduct}
+            onAssign={handleAssignProduct}
+            onUnassign={handleUnassignProduct}
+            isProcessing={assignmentProcessing}
+            adUsers={adUsers}
+            canManage={canManage}
+          />
+          <AssignmentHistory history={assignmentHistory} loading={historyLoading} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default AssignmentsPage;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,223 +1,22 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import AssignmentHistory from '../components/AssignmentHistory';
-import DispatchGuideManager from '../components/DispatchGuideManager';
-import ProductAssignmentPanel from '../components/ProductAssignmentPanel';
-import ProductForm from '../components/ProductForm';
-import ProductTable from '../components/ProductTable';
-import { getApiUrl } from '../api/client';
+import { NavLink, Outlet } from 'react-router-dom';
+import { useMemo } from 'react';
 import { useAuth } from '../hooks/useAuth';
 
+const NAV_ITEMS = [
+  { to: '.', label: 'Inventario', end: true },
+  { to: 'asignaciones', label: 'Asignaciones', requiresManage: true },
+  { to: 'productos/nuevo', label: 'Ingresar producto', requiresManage: true },
+  { to: 'guias', label: 'Guías de despacho', requiresManage: true },
+  { to: 'bajas', label: 'Bajas de inventario', requiresManage: true },
+];
+
 function Dashboard() {
-  const { user, token, logout, hasRole, request } = useAuth();
-  const [products, setProducts] = useState([]);
-  const [productsError, setProductsError] = useState('');
-  const [loadingProducts, setLoadingProducts] = useState(false);
-  const [selectedProductId, setSelectedProductId] = useState(null);
-  const [assignmentHistory, setAssignmentHistory] = useState([]);
-  const [historyLoading, setHistoryLoading] = useState(false);
-  const [dispatchGuides, setDispatchGuides] = useState([]);
-  const [guidesLoading, setGuidesLoading] = useState(false);
-  const [creatingProduct, setCreatingProduct] = useState(false);
-  const [assignmentProcessing, setAssignmentProcessing] = useState(false);
-  const [uploadingGuide, setUploadingGuide] = useState(false);
-  const [adUsers, setAdUsers] = useState([]);
-  const [adError, setAdError] = useState('');
-
+  const { user, logout, hasRole } = useAuth();
   const canManage = hasRole('ADMIN', 'MANAGER');
-  const canAccessGuides = canManage;
 
-  const selectedProduct = useMemo(
-    () => products.find((product) => product._id === selectedProductId) || null,
-    [products, selectedProductId]
-  );
-
-  const loadProducts = useCallback(async () => {
-    setLoadingProducts(true);
-    setProductsError('');
-    try {
-      const data = await request('/products');
-      setProducts(data);
-      setSelectedProductId((current) => {
-        if (!data.length) {
-          return null;
-        }
-        if (!current) {
-          return data[0]._id;
-        }
-        return data.some((item) => item._id === current) ? current : data[0]._id;
-      });
-    } catch (error) {
-      setProductsError(error.message || 'No se pudo obtener el inventario.');
-    } finally {
-      setLoadingProducts(false);
-    }
-  }, [request]);
-
-  const loadAssignmentHistory = useCallback(
-    async (productId) => {
-      if (!productId) {
-        setAssignmentHistory([]);
-        return;
-      }
-      setHistoryLoading(true);
-      try {
-        const history = await request(`/products/${productId}/assignments`);
-        setAssignmentHistory(history);
-      } catch (error) {
-        setAssignmentHistory([]);
-      } finally {
-        setHistoryLoading(false);
-      }
-    },
-    [request]
-  );
-
-  const loadDispatchGuides = useCallback(async () => {
-    if (!canAccessGuides) {
-      return;
-    }
-    setGuidesLoading(true);
-    try {
-      const guides = await request('/dispatch-guides');
-      setDispatchGuides(guides);
-    } catch (error) {
-      console.error('No se pudieron cargar las guías de despacho', error);
-    } finally {
-      setGuidesLoading(false);
-    }
-  }, [canAccessGuides, request]);
-
-  const loadAdUsers = useCallback(async () => {
-    if (!canManage) {
-      setAdUsers([]);
-      return;
-    }
-    try {
-      const users = await request('/ad/users');
-      setAdUsers(users);
-      setAdError('');
-    } catch (error) {
-      setAdError('No se pudieron sincronizar los usuarios de Active Directory simulado.');
-      setAdUsers([]);
-    }
-  }, [canManage, request]);
-
-  useEffect(() => {
-    loadProducts();
-  }, [loadProducts]);
-
-  useEffect(() => {
-    if (selectedProductId) {
-      loadAssignmentHistory(selectedProductId);
-    } else {
-      setAssignmentHistory([]);
-    }
-  }, [selectedProductId, loadAssignmentHistory]);
-
-  useEffect(() => {
-    loadDispatchGuides();
-    loadAdUsers();
-  }, [loadDispatchGuides, loadAdUsers]);
-
-  const handleCreateProduct = useCallback(
-    async (payload) => {
-      setCreatingProduct(true);
-      try {
-        await request('/products', {
-          method: 'POST',
-          data: payload,
-        });
-        await loadProducts();
-      } finally {
-        setCreatingProduct(false);
-      }
-    },
-    [request, loadProducts]
-  );
-
-  const handleAssignProduct = useCallback(
-    async (payload) => {
-      if (!selectedProductId) {
-        return;
-      }
-      setAssignmentProcessing(true);
-      try {
-        await request(`/products/${selectedProductId}/assign`, {
-          method: 'POST',
-          data: payload,
-        });
-        await loadProducts();
-        await loadAssignmentHistory(selectedProductId);
-      } finally {
-        setAssignmentProcessing(false);
-      }
-    },
-    [request, selectedProductId, loadProducts, loadAssignmentHistory]
-  );
-
-  const handleUnassignProduct = useCallback(
-    async (payload) => {
-      if (!selectedProductId) {
-        return;
-      }
-      setAssignmentProcessing(true);
-      try {
-        await request(`/products/${selectedProductId}/unassign`, {
-          method: 'POST',
-          data: payload,
-        });
-        await loadProducts();
-        await loadAssignmentHistory(selectedProductId);
-      } finally {
-        setAssignmentProcessing(false);
-      }
-    },
-    [request, selectedProductId, loadProducts, loadAssignmentHistory]
-  );
-
-  const handleUploadGuide = useCallback(
-    async (formData) => {
-      setUploadingGuide(true);
-      try {
-        await request('/dispatch-guides', {
-          method: 'POST',
-          formData,
-        });
-        await loadDispatchGuides();
-      } finally {
-        setUploadingGuide(false);
-      }
-    },
-    [request, loadDispatchGuides]
-  );
-
-  const handleDownloadGuide = useCallback(
-    async (guide) => {
-      try {
-        const response = await fetch(`${getApiUrl()}/dispatch-guides/${guide._id}/download`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error('No se pudo descargar el archivo.');
-        }
-
-        const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = guide.fileName || `${guide.guideNumber}.pdf`;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        window.URL.revokeObjectURL(url);
-      } catch (error) {
-        alert(error.message || 'No se pudo descargar la guía.');
-      }
-    },
-    [token]
+  const navItems = useMemo(
+    () => NAV_ITEMS.filter((item) => !item.requiresManage || canManage),
+    [canManage]
   );
 
   return (
@@ -232,95 +31,24 @@ function Dashboard() {
         </button>
       </header>
 
-      <section className="dashboard-section">
-        <div className="section-header">
-          <div>
-            <h2>Inventario general</h2>
-            <p className="muted">Revisa el stock total disponible en bodega.</p>
-          </div>
-          <div className="section-actions">
-            <button
-              type="button"
-              className="secondary"
-              onClick={loadProducts}
-              disabled={loadingProducts}
-            >
-              {loadingProducts ? 'Actualizando...' : 'Actualizar stock'}
-            </button>
-          </div>
-        </div>
+      <nav className="dashboard-nav">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            className={({ isActive }) =>
+              isActive ? 'dashboard-nav-link active' : 'dashboard-nav-link'
+            }
+          >
+            {item.label}
+          </NavLink>
+        ))}
+      </nav>
 
-        {productsError && (
-          <div className="card">
-            <strong>Error:</strong> {productsError}
-          </div>
-        )}
-
-        <ProductTable
-          products={products}
-          onSelect={setSelectedProductId}
-          selectedProductId={selectedProductId}
-        />
-      </section>
-
-      <section className="dashboard-section">
-        <div className="section-header">
-          <div>
-            <h2>Asignaciones</h2>
-            <p className="muted">
-              Gestiona la entrega de equipos y revisa el historial de movimientos.
-            </p>
-          </div>
-        </div>
-
-        {adError && canManage && (
-          <div className="card">
-            <strong>Advertencia:</strong> {adError}
-          </div>
-        )}
-
-        <div className="dashboard-grid">
-          <ProductAssignmentPanel
-            product={selectedProduct}
-            onAssign={handleAssignProduct}
-            onUnassign={handleUnassignProduct}
-            adUsers={adUsers}
-            isProcessing={assignmentProcessing}
-            canManage={canManage}
-          />
-          <AssignmentHistory history={assignmentHistory} loading={historyLoading} />
-        </div>
-      </section>
-
-      {canManage && (
-        <section className="dashboard-section">
-          <div className="section-header">
-            <div>
-              <h2>Ingresos</h2>
-              <p className="muted">
-                Registra nuevos equipos y respáldalos con su guía de despacho.
-              </p>
-            </div>
-          </div>
-
-          <div className="dashboard-grid secondary">
-            <ProductForm
-              onSubmit={handleCreateProduct}
-              dispatchGuides={dispatchGuides}
-              isSubmitting={creatingProduct}
-            />
-            {canAccessGuides && (
-              <DispatchGuideManager
-                guides={dispatchGuides}
-                onUpload={handleUploadGuide}
-                onRefresh={loadDispatchGuides}
-                onDownload={handleDownloadGuide}
-                isUploading={uploadingGuide || guidesLoading}
-              />
-            )}
-          </div>
-        </section>
-      )}
+      <main className="dashboard-content">
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/frontend/src/pages/DispatchGuidesPage.jsx
+++ b/frontend/src/pages/DispatchGuidesPage.jsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from 'react';
+import DispatchGuideManager from '../components/DispatchGuideManager';
+import { getApiUrl } from '../api/client';
+import { useAuth } from '../hooks/useAuth';
+
+function DispatchGuidesPage() {
+  const { request, token, hasRole } = useAuth();
+  const [guides, setGuides] = useState([]);
+  const [loadingGuides, setLoadingGuides] = useState(false);
+  const [uploadingGuide, setUploadingGuide] = useState(false);
+  const [error, setError] = useState('');
+
+  const canManage = hasRole('ADMIN', 'MANAGER');
+
+  const loadGuides = useCallback(async () => {
+    setLoadingGuides(true);
+    setError('');
+    try {
+      const data = await request('/dispatch-guides');
+      setGuides(data);
+    } catch (err) {
+      setError(err.message || 'No se pudieron obtener las guías de despacho.');
+      setGuides([]);
+    } finally {
+      setLoadingGuides(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    if (canManage) {
+      loadGuides();
+    }
+  }, [loadGuides, canManage]);
+
+  const handleUploadGuide = useCallback(
+    async (formData) => {
+      setUploadingGuide(true);
+      setError('');
+      try {
+        await request('/dispatch-guides', {
+          method: 'POST',
+          formData,
+        });
+        await loadGuides();
+      } finally {
+        setUploadingGuide(false);
+      }
+    },
+    [request, loadGuides]
+  );
+
+  const handleDownloadGuide = useCallback(
+    async (guide) => {
+      try {
+        const response = await fetch(`${getApiUrl()}/dispatch-guides/${guide._id}/download`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('No se pudo descargar la guía de despacho.');
+        }
+
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = guide.fileName || `${guide.guideNumber}.pdf`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        window.URL.revokeObjectURL(url);
+      } catch (downloadError) {
+        alert(downloadError.message || 'No se pudo descargar la guía de despacho.');
+      }
+    },
+    [token]
+  );
+
+  const handleDeleteGuide = useCallback(
+    async (guide) => {
+      const confirmed = window.confirm(
+        `¿Deseas eliminar la guía ${guide.guideNumber}? Esta acción no se puede deshacer.`
+      );
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await request(`/dispatch-guides/${guide._id}`, { method: 'DELETE' });
+        await loadGuides();
+      } catch (deleteError) {
+        alert(deleteError.message || 'No se pudo eliminar la guía de despacho.');
+      }
+    },
+    [request, loadGuides]
+  );
+
+  if (!canManage) {
+    return (
+      <section className="dashboard-section">
+        <div className="card">
+          <h2>Guías de despacho</h2>
+          <p className="muted">
+            No tienes permisos para gestionar guías de despacho.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Guías de despacho</h2>
+          <p className="muted">Administra los respaldos de ingreso de inventario.</p>
+        </div>
+        <div className="section-actions">
+          <button
+            type="button"
+            className="secondary"
+            onClick={loadGuides}
+            disabled={loadingGuides}
+          >
+            {loadingGuides ? 'Actualizando...' : 'Actualizar listado'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="card">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <DispatchGuideManager
+        guides={guides}
+        onUpload={handleUploadGuide}
+        onRefresh={loadGuides}
+        onDownload={handleDownloadGuide}
+        onDelete={handleDeleteGuide}
+        isUploading={uploadingGuide}
+      />
+    </section>
+  );
+}
+
+export default DispatchGuidesPage;

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -1,0 +1,267 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import ProductTable from '../components/ProductTable';
+import { useAuth } from '../hooks/useAuth';
+import { getProductStatusBadge, getProductStatusLabel } from '../utils/productStatus';
+
+const STATUS_FILTERS = [
+  { value: 'ALL', label: 'Todos' },
+  { value: 'AVAILABLE', label: 'Disponibles' },
+  { value: 'ASSIGNED', label: 'Asignados' },
+  { value: 'DECOMMISSIONED', label: 'Dados de baja' },
+];
+
+function formatType(type) {
+  if (type === 'PURCHASED') {
+    return 'Compra';
+  }
+  if (type === 'RENTAL') {
+    return 'Arriendo';
+  }
+  return type;
+}
+
+function InventoryPage() {
+  const { request, hasRole } = useAuth();
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [selectedProductId, setSelectedProductId] = useState(null);
+  const [statusFilter, setStatusFilter] = useState('ALL');
+  const [deleting, setDeleting] = useState(false);
+
+  const canManage = hasRole('ADMIN', 'MANAGER');
+
+  const applyFilter = useCallback(
+    (list, filterValue = statusFilter) => {
+      if (filterValue === 'ALL') {
+        return list;
+      }
+      return list.filter((item) => item.status === filterValue);
+    },
+    [statusFilter]
+  );
+
+  const loadProducts = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await request('/products');
+      setProducts(data);
+      const filtered = applyFilter(data);
+      setSelectedProductId((current) => {
+        if (!filtered.length) {
+          return null;
+        }
+        if (current && filtered.some((item) => item._id === current)) {
+          return current;
+        }
+        return filtered[0]._id;
+      });
+    } catch (err) {
+      setError(err.message || 'No se pudo obtener el inventario.');
+    } finally {
+      setLoading(false);
+    }
+  }, [request, applyFilter]);
+
+  useEffect(() => {
+    loadProducts();
+  }, [loadProducts]);
+
+  const filteredProducts = useMemo(() => applyFilter(products), [products, applyFilter]);
+
+  const selectedProduct = useMemo(
+    () => products.find((product) => product._id === selectedProductId) || null,
+    [products, selectedProductId]
+  );
+
+  const handleFilterChange = (event) => {
+    const value = event.target.value;
+    setStatusFilter(value);
+    setSelectedProductId((current) => {
+      const filtered = applyFilter(products, value);
+      if (!filtered.length) {
+        return null;
+      }
+      if (current && filtered.some((item) => item._id === current)) {
+        return current;
+      }
+      return filtered[0]._id;
+    });
+  };
+
+  const handleDeleteProduct = useCallback(async () => {
+    if (!selectedProduct || !canManage) {
+      return;
+    }
+
+    if (selectedProduct.status === 'ASSIGNED') {
+      alert('Debes liberar la asignación antes de eliminar el producto.');
+      return;
+    }
+
+    const confirmed = window.confirm(
+      '¿Estás seguro de eliminar este producto? Esta acción no se puede deshacer.'
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setDeleting(true);
+    try {
+      await request(`/products/${selectedProduct._id}`, { method: 'DELETE' });
+      await loadProducts();
+    } catch (err) {
+      alert(err.message || 'No se pudo eliminar el producto.');
+    } finally {
+      setDeleting(false);
+    }
+  }, [selectedProduct, canManage, request, loadProducts]);
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Inventario</h2>
+          <p className="muted">Consulta el detalle de los productos registrados en bodega.</p>
+        </div>
+        <div className="section-actions">
+          <label className="inline-filter">
+            Estado
+            <select value={statusFilter} onChange={handleFilterChange}>
+              {STATUS_FILTERS.map((filter) => (
+                <option key={filter.value} value={filter.value}>
+                  {filter.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" className="secondary" onClick={loadProducts} disabled={loading}>
+            {loading ? 'Actualizando...' : 'Actualizar'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="card">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <div className="dashboard-grid">
+        <ProductTable
+          products={filteredProducts}
+          onSelect={setSelectedProductId}
+          selectedProductId={selectedProductId}
+        />
+        <div className="card">
+          <div className="card-header">
+            <h3>Detalle del producto</h3>
+            <p className="muted">
+              {selectedProduct
+                ? `Registrado el ${new Date(selectedProduct.createdAt).toLocaleDateString('es-CL')}`
+                : 'Selecciona un producto para ver su detalle.'}
+            </p>
+          </div>
+
+          {!selectedProduct && <p className="muted">No hay productos que coincidan con el filtro.</p>}
+
+          {selectedProduct && (
+            <>
+              <div className="detail-grid">
+                <div>
+                  <strong>Nombre:</strong> {selectedProduct.name}
+                </div>
+                <div>
+                  <strong>Tipo:</strong> {formatType(selectedProduct.type)}
+                </div>
+                <div>
+                  <strong>N° serie:</strong> {selectedProduct.serialNumber}
+                </div>
+                <div>
+                  <strong>N° parte:</strong> {selectedProduct.partNumber}
+                </div>
+                {selectedProduct.type === 'PURCHASED' ? (
+                  <div>
+                    <strong>N° inventario:</strong> {selectedProduct.inventoryNumber || '—'}
+                  </div>
+                ) : (
+                  <div>
+                    <strong>ID arriendo:</strong> {selectedProduct.rentalId}
+                  </div>
+                )}
+                <div>
+                  <strong>Guía:</strong> {selectedProduct.dispatchGuide?.guideNumber || '—'}
+                </div>
+                {selectedProduct.description && (
+                  <div className="full-row">
+                    <strong>Descripción:</strong> {selectedProduct.description}
+                  </div>
+                )}
+                <div className="full-row">
+                  <strong>Estado:</strong>{' '}
+                  <span className={getProductStatusBadge(selectedProduct.status)}>
+                    {getProductStatusLabel(selectedProduct.status)}
+                  </span>
+                </div>
+              </div>
+
+              {selectedProduct.status === 'ASSIGNED' && selectedProduct.currentAssignment && (
+                <div className="assignment-box">
+                  <p>
+                    <strong>{selectedProduct.currentAssignment.assignedTo}</strong> ·{' '}
+                    {selectedProduct.currentAssignment.assignedToAdAccount}
+                  </p>
+                  <p className="muted">
+                    Ubicación: {selectedProduct.currentAssignment.location} ·{' '}
+                    {new Date(
+                      selectedProduct.currentAssignment.assignmentDate
+                    ).toLocaleString('es-CL')}
+                  </p>
+                </div>
+              )}
+
+              {selectedProduct.status === 'DECOMMISSIONED' && (
+                <div className="assignment-box">
+                  <p>
+                    <strong>Motivo de baja:</strong> {selectedProduct.decommissionReason}
+                  </p>
+                  <p className="muted">
+                    Registrado el{' '}
+                    {selectedProduct.decommissionedAt
+                      ? new Date(selectedProduct.decommissionedAt).toLocaleString('es-CL')
+                      : '—'}
+                    {selectedProduct.decommissionedBy?.name
+                      ? ` · Por ${selectedProduct.decommissionedBy.name}`
+                      : ''}
+                  </p>
+                </div>
+              )}
+
+              {canManage && (
+                <div className="section-actions">
+                  <button
+                    type="button"
+                    className="danger"
+                    onClick={handleDeleteProduct}
+                    disabled={deleting || selectedProduct.status === 'ASSIGNED'}
+                  >
+                    {deleting ? 'Eliminando...' : 'Eliminar producto'}
+                  </button>
+                </div>
+              )}
+              {canManage && selectedProduct.status === 'ASSIGNED' && (
+                <p className="muted small-text">
+                  Debes liberar la asignación antes de eliminar el producto.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default InventoryPage;

--- a/frontend/src/pages/ProductDecommissionPage.jsx
+++ b/frontend/src/pages/ProductDecommissionPage.jsx
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import ProductTable from '../components/ProductTable';
+import { useAuth } from '../hooks/useAuth';
+import { getProductStatusBadge, getProductStatusLabel } from '../utils/productStatus';
+
+function ProductDecommissionPage() {
+  const { request, hasRole } = useAuth();
+  const [products, setProducts] = useState([]);
+  const [selectedProductId, setSelectedProductId] = useState(null);
+  const [reason, setReason] = useState('');
+  const [formError, setFormError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const canManage = hasRole('ADMIN', 'MANAGER');
+
+  const loadProducts = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await request('/products');
+      setProducts(data);
+    } catch (err) {
+      setError(err.message || 'No se pudo obtener el inventario.');
+      setProducts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    if (canManage) {
+      loadProducts();
+    }
+  }, [loadProducts, canManage]);
+
+  const activeProducts = useMemo(
+    () => products.filter((product) => product.status !== 'DECOMMISSIONED'),
+    [products]
+  );
+
+  const decommissionedProducts = useMemo(
+    () => products.filter((product) => product.status === 'DECOMMISSIONED'),
+    [products]
+  );
+
+  useEffect(() => {
+    setSelectedProductId((current) => {
+      if (!activeProducts.length) {
+        return null;
+      }
+      if (current && activeProducts.some((item) => item._id === current)) {
+        return current;
+      }
+      return activeProducts[0]._id;
+    });
+  }, [activeProducts]);
+
+  const selectedProduct = useMemo(
+    () => activeProducts.find((product) => product._id === selectedProductId) || null,
+    [activeProducts, selectedProductId]
+  );
+
+  useEffect(() => {
+    setReason('');
+    setFormError('');
+  }, [selectedProductId]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setFormError('');
+
+    if (!selectedProduct) {
+      setFormError('Selecciona un producto disponible.');
+      return;
+    }
+
+    if (selectedProduct.status !== 'AVAILABLE') {
+      setFormError('Debes liberar la asignación antes de dar de baja este producto.');
+      return;
+    }
+
+    if (!reason.trim()) {
+      setFormError('Indica el motivo de la baja.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await request(`/products/${selectedProduct._id}/decommission`, {
+        method: 'POST',
+        data: { reason: reason.trim() },
+      });
+      setReason('');
+      await loadProducts();
+    } catch (submitError) {
+      setFormError(submitError.message || 'No se pudo dar de baja el producto.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!canManage) {
+    return (
+      <section className="dashboard-section">
+        <div className="card">
+          <h2>Dar de baja productos</h2>
+          <p className="muted">Solo los administradores o encargados pueden dar de baja equipos.</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Dar de baja productos</h2>
+          <p className="muted">Registra la baja de equipos e indica el motivo correspondiente.</p>
+        </div>
+        <div className="section-actions">
+          <button type="button" className="secondary" onClick={loadProducts} disabled={loading}>
+            {loading ? 'Actualizando...' : 'Actualizar inventario'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="card">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <div className="dashboard-grid secondary">
+        <ProductTable
+          products={activeProducts}
+          onSelect={setSelectedProductId}
+          selectedProductId={selectedProductId}
+        />
+        <div className="card">
+          <div className="card-header">
+            <h3>Baja de inventario</h3>
+            <p className="muted">
+              Selecciona un producto disponible y detalla el motivo de la baja.
+            </p>
+          </div>
+
+          {!selectedProduct && (
+            <p className="muted">No hay productos disponibles para dar de baja.</p>
+          )}
+
+          {selectedProduct && (
+            <form className="form-grid" onSubmit={handleSubmit}>
+              <div className="full-width">
+                <strong>{selectedProduct.name}</strong>{' '}
+                <span className="muted">({selectedProduct.serialNumber})</span>
+              </div>
+              <div className="full-width">
+                <span className={getProductStatusBadge(selectedProduct.status)}>
+                  {getProductStatusLabel(selectedProduct.status)}
+                </span>
+              </div>
+              {selectedProduct.status === 'ASSIGNED' && selectedProduct.currentAssignment && (
+                <div className="full-width muted small-text">
+                  Actualmente asignado a {selectedProduct.currentAssignment.assignedTo} en{' '}
+                  {selectedProduct.currentAssignment.location}.
+                </div>
+              )}
+              <label className="full-width">
+                Motivo
+                <textarea
+                  value={reason}
+                  onChange={(event) => setReason(event.target.value)}
+                  rows={4}
+                  placeholder="Describe la razón de la baja"
+                  disabled={selectedProduct.status !== 'AVAILABLE'}
+                />
+              </label>
+              {formError && <p className="error">{formError}</p>}
+              <button
+                type="submit"
+                className="danger"
+                disabled={submitting || selectedProduct.status !== 'AVAILABLE'}
+              >
+                {submitting ? 'Registrando...' : 'Registrar baja'}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-header">
+          <h3>Historial de bajas</h3>
+          <p className="muted">Consulta los equipos dados de baja y su motivo.</p>
+        </div>
+        <div className="table-responsive">
+          <table className="data-table compact">
+            <thead>
+              <tr>
+                <th>Producto</th>
+                <th>N° serie</th>
+                <th>Motivo</th>
+                <th>Registrado</th>
+              </tr>
+            </thead>
+            <tbody>
+              {decommissionedProducts.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="muted">
+                    Aún no se registran bajas.
+                  </td>
+                </tr>
+              )}
+              {decommissionedProducts.map((product) => (
+                <tr key={product._id}>
+                  <td>{product.name}</td>
+                  <td>{product.serialNumber}</td>
+                  <td>{product.decommissionReason || '—'}</td>
+                  <td>
+                    {product.decommissionedAt
+                      ? new Date(product.decommissionedAt).toLocaleString('es-CL')
+                      : '—'}
+                    {product.decommissionedBy?.name ? ` · ${product.decommissionedBy.name}` : ''}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default ProductDecommissionPage;

--- a/frontend/src/pages/ProductEntryPage.jsx
+++ b/frontend/src/pages/ProductEntryPage.jsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from 'react';
+import ProductForm from '../components/ProductForm';
+import { useAuth } from '../hooks/useAuth';
+
+function ProductEntryPage() {
+  const { request, hasRole } = useAuth();
+  const [dispatchGuides, setDispatchGuides] = useState([]);
+  const [loadingGuides, setLoadingGuides] = useState(false);
+  const [guidesError, setGuidesError] = useState('');
+  const [creatingProduct, setCreatingProduct] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const canManage = hasRole('ADMIN', 'MANAGER');
+
+  const loadDispatchGuides = useCallback(async () => {
+    setLoadingGuides(true);
+    setGuidesError('');
+    try {
+      const guides = await request('/dispatch-guides');
+      setDispatchGuides(guides);
+    } catch (error) {
+      setGuidesError(error.message || 'No se pudieron obtener las guías de despacho.');
+      setDispatchGuides([]);
+    } finally {
+      setLoadingGuides(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    if (canManage) {
+      loadDispatchGuides();
+    }
+  }, [loadDispatchGuides, canManage]);
+
+  const handleCreateProduct = useCallback(
+    async (payload) => {
+      setCreatingProduct(true);
+      setSuccessMessage('');
+      try {
+        await request('/products', {
+          method: 'POST',
+          data: payload,
+        });
+        setSuccessMessage('Producto registrado correctamente.');
+      } catch (error) {
+        setSuccessMessage('');
+        throw error;
+      } finally {
+        setCreatingProduct(false);
+      }
+    },
+    [request]
+  );
+
+  if (!canManage) {
+    return (
+      <section className="dashboard-section">
+        <div className="card">
+          <h2>Ingresar producto</h2>
+          <p className="muted">
+            Solo los administradores o encargados pueden registrar nuevos productos.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Ingresar producto</h2>
+          <p className="muted">
+            Registra equipos nuevos y asócialos a la guía de despacho correspondiente.
+          </p>
+        </div>
+        <div className="section-actions">
+          <button
+            type="button"
+            className="secondary"
+            onClick={loadDispatchGuides}
+            disabled={loadingGuides}
+          >
+            {loadingGuides ? 'Actualizando...' : 'Actualizar guías'}
+          </button>
+        </div>
+      </div>
+
+      {guidesError && (
+        <div className="card">
+          <strong>Error:</strong> {guidesError}
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="card success-card">
+          <strong>Éxito:</strong> {successMessage}
+        </div>
+      )}
+
+      <ProductForm
+        onSubmit={handleCreateProduct}
+        dispatchGuides={dispatchGuides}
+        isSubmitting={creatingProduct}
+      />
+    </section>
+  );
+}
+
+export default ProductEntryPage;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -93,6 +93,12 @@ button {
   font-weight: 600;
 }
 
+button.compact {
+  padding: 0.5rem 0.85rem;
+  font-size: 0.85rem;
+  border-radius: 10px;
+}
+
 button.primary {
   background: linear-gradient(135deg, #2563eb, #1d4ed8);
   color: #ffffff;
@@ -136,6 +142,41 @@ small,
   padding: 2rem;
   max-width: 1200px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 12px 24px -24px rgba(15, 23, 42, 0.35);
+}
+
+.dashboard-nav-link {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: #1d4ed8;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-nav-link:hover {
+  background-color: rgba(37, 99, 235, 0.12);
+}
+
+.dashboard-nav-link.active {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 10px 20px -18px rgba(37, 99, 235, 0.9);
+}
+
+.dashboard-content {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -238,6 +279,11 @@ small,
   color: #b45309;
 }
 
+.status.danger {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
 .form-grid {
   display: grid;
   gap: 1rem;
@@ -251,6 +297,38 @@ small,
 
 .form-grid .full-width {
   grid-column: 1 / -1;
+}
+
+.detail-grid .full-row {
+  grid-column: 1 / -1;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.inline-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.inline-filter select {
+  min-width: 160px;
+}
+
+.card.success-card {
+  background: #ecfdf3;
+  border-left: 4px solid #16a34a;
+  color: #065f46;
+}
+
+.card.success-card strong {
+  color: inherit;
 }
 
 .detail-grid {
@@ -281,6 +359,12 @@ small,
   color: #ef4444;
 }
 
+button.danger {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  color: #ffffff;
+  box-shadow: 0 12px 24px -16px rgba(239, 68, 68, 0.6);
+}
+
 @media (max-width: 960px) {
   .dashboard-grid {
     grid-template-columns: 1fr;
@@ -297,5 +381,15 @@ small,
 
   .section-actions {
     justify-content: flex-start;
+  }
+
+  .dashboard-nav {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dashboard-nav-link {
+    width: 100%;
+    text-align: center;
   }
 }

--- a/frontend/src/utils/productStatus.js
+++ b/frontend/src/utils/productStatus.js
@@ -1,0 +1,33 @@
+const PRODUCT_STATUS_CONFIG = {
+  AVAILABLE: {
+    label: 'Disponible',
+    badge: 'success',
+  },
+  ASSIGNED: {
+    label: 'Asignado',
+    badge: 'info',
+  },
+  DECOMMISSIONED: {
+    label: 'Dado de baja',
+    badge: 'danger',
+  },
+};
+
+export function getProductStatusLabel(status) {
+  if (!status) {
+    return 'Desconocido';
+  }
+  return PRODUCT_STATUS_CONFIG[status]?.label || status;
+}
+
+export function getProductStatusBadge(status) {
+  if (!status) {
+    return 'status info';
+  }
+  const badge = PRODUCT_STATUS_CONFIG[status]?.badge || 'info';
+  return `status ${badge}`;
+}
+
+export function isDecommissioned(status) {
+  return status === 'DECOMMISSIONED';
+}


### PR DESCRIPTION
## Summary
- add product lifecycle fields plus filtering, delete, and decommission endpoints, and allow dispatch guide removal when unused
- replace the single dashboard view with routed pages for inventory, assignments, product entry, dispatch guides, and decommission workflows, including shared status helpers
- enhance UI components to surface product states, deletion controls, Active Directory assignment history notes, and updated styling for the new navigation

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d351e7593c8321bdc5ed083a6cffae