### PR TITLE
feat(frontend): refresh ui with chileatiende styling

### DIFF
--- a/frontend/src/assets/chileatiende-logo.svg
+++ b/frontend/src/assets/chileatiende-logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img">
+  <title>ChileAtiende</title>
+  <defs>
+    <linearGradient id="blueGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b67b3" />
+      <stop offset="100%" stop-color="#0095d9" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="112" height="120" rx="18" fill="url(#blueGradient)" />
+  <polygon points="28,18 32.5,30 45,30 35,38 38,50 28,43 18,50 21,38 11,30 23.5,30" fill="#fff" />
+  <circle cx="52" cy="46" r="17" fill="#ffffff" opacity="0.95" />
+  <path d="M52 63c14 0 21 9 21 23v12H31V86c0-14 7-23 21-23z" fill="#ffffff" opacity="0.95" />
+  <circle cx="78" cy="70" r="11" fill="#ffffff" opacity="0.85" />
+  <path d="M78 82c8 0 12 5 12 13v13H66V95c0-8 4-13 12-13z" fill="#ffffff" opacity="0.85" />
+  <g fill="#0b3c75" font-family="'Montserrat', 'Segoe UI', sans-serif" font-weight="700">
+    <text x="128" y="56" font-size="36">Chile</text>
+    <text x="128" y="95" font-size="38">Atiende</text>
+  </g>
+  <rect x="128" y="22" width="150" height="6" fill="#e63946" rx="3" />
+</svg>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { NavLink, Outlet } from 'react-router-dom';
 import { useMemo } from 'react';
 import { useAuth } from '../hooks/useAuth';
+import chileAtiendeLogo from '../assets/chileatiende-logo.svg';
 
 const NAV_ITEMS = [
   { to: '.', label: 'Inventario', end: true },
@@ -21,14 +22,24 @@ function Dashboard() {
 
   return (
     <div className="dashboard">
-      <header className="dashboard-header">
-        <div>
-          <h1>Bienvenido, {user.name}</h1>
-          <p className="muted">Rol: {user.role}</p>
+      <header className="dashboard-hero">
+        <div className="dashboard-brand">
+          <img src={chileAtiendeLogo} alt="ChileAtiende" className="dashboard-brand-logo" />
+          <div>
+            <p className="dashboard-brand-eyebrow">Red de atención ciudadana</p>
+            <h1>Panel de gestión de bodega</h1>
+          </div>
         </div>
-        <button type="button" className="logout" onClick={logout}>
-          Cerrar sesión
-        </button>
+        <div className="dashboard-user">
+          <div>
+            <span className="dashboard-user-hello">Hola,</span>
+            <p className="dashboard-user-name">{user.name}</p>
+            <span className="muted">Rol: {user.role}</span>
+          </div>
+          <button type="button" className="logout" onClick={logout}>
+            Cerrar sesión
+          </button>
+        </div>
       </header>
 
       <nav className="dashboard-nav">

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import chileAtiendeLogo from '../assets/chileatiende-logo.svg';
 
 function LoginPage() {
   const navigate = useNavigate();
@@ -33,38 +34,59 @@ function LoginPage() {
 
   return (
     <div className="auth-layout">
-      <form className="card" onSubmit={handleSubmit}>
-        <h1>Administración de Bodega</h1>
-        <p className="muted">Ingresa con tu correo corporativo y contraseña.</p>
-        <label>
-          Correo electrónico
-          <input
-            type="email"
-            name="email"
-            value={formValues.email}
-            onChange={handleChange}
-            required
-          />
-        </label>
-        <label>
-          Contraseña
-          <input
-            type="password"
-            name="password"
-            value={formValues.password}
-            onChange={handleChange}
-            required
-          />
-        </label>
-        {error && <p className="error">{error}</p>}
-        <button type="submit" disabled={loading}>
-          {loading ? 'Ingresando...' : 'Ingresar'}
-        </button>
-        <p className="muted small-text">
-          Si es la primera vez que utilizas el sistema solicita a un administrador que cree tu
-          cuenta o ejecuta el script de aprovisionamiento.
-        </p>
-      </form>
+      <div className="auth-card">
+        <section className="auth-brand" aria-labelledby="auth-brand-title">
+          <img src={chileAtiendeLogo} alt="ChileAtiende" className="auth-brand-logo" />
+          <div className="auth-brand-copy">
+            <p className="auth-brand-eyebrow">Red de atención ciudadana</p>
+            <h1 id="auth-brand-title">Gestión de bodega ChileAtiende</h1>
+            <p>
+              Coordina la administración de recursos tecnológicos con la calidez y cercanía de la
+              red ChileAtiende.
+            </p>
+          </div>
+          <ul className="auth-brand-highlights">
+            <li>Seguimiento transparente del inventario público.</li>
+            <li>Asignaciones y guías alineadas con protocolos estatales.</li>
+            <li>Soporte para equipos regionales y centrales.</li>
+          </ul>
+        </section>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <div className="auth-form-header">
+            <h2>Iniciar sesión</h2>
+            <p className="muted">Ingresa con tu correo corporativo y contraseña.</p>
+          </div>
+          <label>
+            Correo electrónico
+            <input
+              type="email"
+              name="email"
+              value={formValues.email}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <label>
+            Contraseña
+            <input
+              type="password"
+              name="password"
+              value={formValues.password}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          {error && <p className="error">{error}</p>}
+          <button type="submit" className="primary" disabled={loading}>
+            {loading ? 'Ingresando...' : 'Ingresar'}
+          </button>
+          <p className="muted small-text">
+            Si es la primera vez que utilizas el sistema solicita a un administrador que cree tu
+            cuenta o ejecuta el script de aprovisionamiento.
+          </p>
+        </form>
+      </div>
     </div>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,8 +1,30 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Work+Sans:wght@400;500;600&display=swap');
+
 :root {
   color-scheme: light;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f6f7fb;
-  color: #111827;
+  font-family: 'Work Sans', 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f3f7fb;
+  color: #0f2640;
+  --primary-900: #0b2f63;
+  --primary-800: #0c3c75;
+  --primary-700: #005ba8;
+  --primary-600: #0072c7;
+  --primary-500: #0094d9;
+  --primary-300: #5fc1f0;
+  --primary-100: #d6ecff;
+  --primary-50: #eef6ff;
+  --accent-red: #e63946;
+  --accent-red-dark: #c92c33;
+  --neutral-900: #0f2640;
+  --neutral-700: #345071;
+  --neutral-500: #5f7490;
+  --neutral-300: #c2cfdd;
+  --neutral-150: #dce7f3;
+  --surface: #ffffff;
+  --surface-muted: #f6f9fc;
+  --shadow-lg: 0 35px 80px -40px rgba(11, 60, 117, 0.55);
+  --shadow-md: 0 24px 60px -44px rgba(11, 60, 117, 0.45);
+  --shadow-sm: 0 16px 40px -32px rgba(11, 60, 117, 0.25);
 }
 
 * {
@@ -12,43 +34,42 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, #f6f7fb 0%, #e8ebf5 100%);
+  background:
+    radial-gradient(140% 140% at 15% 20%, rgba(0, 148, 217, 0.18), transparent 60%),
+    radial-gradient(120% 120% at 85% 0%, rgba(230, 57, 70, 0.08), transparent 55%),
+    linear-gradient(180deg, #f1f6fb 0%, #f8fbff 100%);
+  color: var(--neutral-900);
+  font-size: 16px;
+  line-height: 1.55;
+  overflow-x: hidden;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
-.auth-layout {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
+h1,
+h2,
+h3 {
+  font-family: 'Montserrat', 'Work Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+  color: var(--neutral-900);
 }
 
-.card {
-  background: #ffffff;
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.35);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.card-header h2,
-.card-header h3 {
+p {
   margin: 0;
 }
 
-.card-header p {
-  margin: 0.25rem 0 0;
+small,
+.muted {
+  color: var(--neutral-500);
+  font-weight: 400;
 }
 
-form.card {
-  max-width: 420px;
-  width: 100%;
+.small-text {
+  font-size: 0.85rem;
 }
 
 label {
@@ -56,7 +77,7 @@ label {
   flex-direction: column;
   gap: 0.5rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--neutral-900);
 }
 
 input,
@@ -69,28 +90,52 @@ button {
 input,
 select,
 textarea {
-  padding: 0.65rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid #d0d6e6;
-  background-color: #f9fafb;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  padding: 0.7rem 0.9rem;
+  border-radius: 12px;
+  border: 1.5px solid rgba(12, 60, 117, 0.18);
+  background-color: #f9fbff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: rgba(52, 80, 113, 0.6);
 }
 
 input:focus,
 select:focus,
 textarea:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  border-color: var(--primary-600);
+  box-shadow: 0 0 0 4px rgba(0, 114, 199, 0.16);
+  background-color: #ffffff;
 }
 
 button {
   border: none;
-  border-radius: 12px;
-  padding: 0.75rem 1.25rem;
+  border-radius: 14px;
+  padding: 0.75rem 1.45rem;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  transition: transform 0.18s ease, box-shadow 0.2s ease, background 0.2s ease;
   font-weight: 600;
+  background: linear-gradient(120deg, var(--primary-700), var(--primary-500));
+  color: #ffffff;
+  box-shadow: 0 22px 38px -24px rgba(0, 91, 166, 0.55);
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 26px 44px -20px rgba(0, 91, 166, 0.55);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 button.compact {
@@ -100,99 +145,338 @@ button.compact {
 }
 
 button.primary {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  background: linear-gradient(120deg, var(--primary-700), var(--primary-500));
   color: #ffffff;
-  box-shadow: 0 12px 24px -16px rgba(37, 99, 235, 0.8);
 }
 
 button.secondary {
   background: #ffffff;
-  border: 1px solid #cbd5f5;
-  color: #1d4ed8;
+  border: 1.5px solid rgba(0, 91, 168, 0.25);
+  color: var(--primary-700);
+  box-shadow: none;
+}
+
+button.secondary:hover:not(:disabled) {
+  background: rgba(0, 148, 217, 0.08);
 }
 
 button.link {
   background: none;
-  color: #2563eb;
+  color: var(--primary-700);
   padding: 0;
   border-radius: 0;
+  box-shadow: none;
 }
 
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+button.link:hover {
+  text-decoration: underline;
 }
 
-small,
-.muted {
-  color: #6b7280;
-  font-weight: 400;
-}
-
-.small-text {
-  font-size: 0.85rem;
+button.danger {
+  background: linear-gradient(120deg, var(--accent-red), var(--accent-red-dark));
+  box-shadow: 0 22px 40px -26px rgba(200, 50, 55, 0.6);
 }
 
 .error {
-  color: #dc2626;
+  color: var(--accent-red-dark);
+  background: rgba(230, 57, 70, 0.12);
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
   font-weight: 600;
 }
 
+.auth-layout {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  background: linear-gradient(140deg, rgba(0, 148, 217, 0.12), transparent 55%),
+    linear-gradient(200deg, rgba(0, 91, 168, 0.08), transparent 60%);
+}
+
+.auth-card {
+  width: min(100%, 1040px);
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(340px, 1fr);
+  background: var(--surface);
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+}
+
+.auth-brand {
+  position: relative;
+  padding: 3rem 2.75rem;
+  background: linear-gradient(140deg, var(--primary-800), var(--primary-600));
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  isolation: isolate;
+}
+
+.auth-brand::after {
+  content: '';
+  position: absolute;
+  inset: 20% -35% -35% 35%;
+  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.45), transparent 65%);
+  opacity: 0.35;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.auth-brand-logo {
+  width: clamp(160px, 18vw, 200px);
+  filter: drop-shadow(0 12px 24px rgba(8, 33, 72, 0.4));
+}
+
+.auth-brand-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.auth-brand-copy h1 {
+  color: #ffffff;
+  font-size: clamp(1.8rem, 1.2rem + 1.5vw, 2.4rem);
+}
+
+.auth-brand-copy p {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1rem;
+}
+
+.auth-brand-highlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.auth-brand-highlights li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.auth-brand-highlights li::before {
+  content: '';
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 0 0 5px rgba(255, 255, 255, 0.28);
+  margin-top: 0.35rem;
+  flex-shrink: 0;
+}
+
+.auth-form {
+  padding: 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.auth-form-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.5rem;
+}
+
+.auth-form-header h2 {
+  font-size: 1.75rem;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.75rem;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(11, 60, 117, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card-header h2,
+.card-header h3 {
+  margin: 0;
+}
+
+.card-header p {
+  margin: 0.35rem 0 0;
+  color: var(--neutral-500);
+}
+
+.card.success-card {
+  background: linear-gradient(120deg, rgba(46, 204, 113, 0.15), rgba(46, 204, 113, 0.08));
+  border-left: 5px solid #2ecc71;
+  color: #0b5130;
+}
+
+.card.success-card strong {
+  color: inherit;
+}
+
 .dashboard {
-  padding: 2rem;
+  padding: 2.75rem 2rem 3.5rem;
   max-width: 1200px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
+  gap: 2rem;
+}
+
+.dashboard-hero {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+  background: linear-gradient(120deg, var(--primary-800), var(--primary-500));
+  color: #ffffff;
+  padding: 2.75rem 3rem;
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+}
+
+.dashboard-hero::after {
+  content: '';
+  position: absolute;
+  inset: -20% -30% 40% 40%;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.6), transparent 60%);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.dashboard-brand {
+  display: flex;
+  align-items: center;
   gap: 1.5rem;
+  z-index: 1;
+}
+
+.dashboard-brand-logo {
+  width: clamp(120px, 12vw, 150px);
+  flex-shrink: 0;
+  filter: drop-shadow(0 14px 28px rgba(8, 33, 72, 0.35));
+}
+
+.dashboard-brand-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 0.5rem;
+}
+
+.dashboard-hero h1 {
+  color: #ffffff;
+  font-size: clamp(1.8rem, 1.3rem + 1.5vw, 2.4rem);
+  margin: 0;
+}
+
+.dashboard-user {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.16);
+  padding: 1.5rem 1.75rem;
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  z-index: 1;
+}
+
+.dashboard-user-hello {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.dashboard-user-name {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin: 0.35rem 0 0.25rem;
+  color: #ffffff;
+}
+
+.dashboard-user .muted {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.logout {
+  background: #ffffff;
+  color: var(--accent-red);
+  border: 1.5px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 20px 40px -28px rgba(11, 60, 117, 0.45);
+  padding: 0.6rem 1.4rem;
+}
+
+.logout:hover {
+  background: rgba(255, 255, 255, 0.92);
 }
 
 .dashboard-nav {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  background: #ffffff;
-  border-radius: 12px;
-  padding: 0.75rem 1rem;
-  box-shadow: 0 12px 24px -24px rgba(15, 23, 42, 0.35);
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 22px;
+  padding: 0.9rem 1rem;
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(11, 60, 117, 0.08);
 }
 
 .dashboard-nav-link {
-  padding: 0.5rem 1rem;
+  position: relative;
+  padding: 0.65rem 1.3rem;
   border-radius: 999px;
   font-weight: 600;
-  color: #1d4ed8;
+  color: var(--primary-700);
   text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(0, 148, 217, 0.08);
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .dashboard-nav-link:hover {
-  background-color: rgba(37, 99, 235, 0.12);
+  background-color: rgba(0, 148, 217, 0.16);
 }
 
 .dashboard-nav-link.active {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  background: linear-gradient(120deg, var(--primary-600), var(--primary-500));
   color: #ffffff;
-  box-shadow: 0 10px 20px -18px rgba(37, 99, 235, 0.9);
+  box-shadow: 0 20px 32px -22px rgba(0, 91, 166, 0.6);
+}
+
+.dashboard-nav-link.active::after {
+  content: '';
+  position: absolute;
+  left: 20px;
+  right: 20px;
+  bottom: -8px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--accent-red);
 }
 
 .dashboard-content {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-}
-
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
+  gap: 1.75rem;
 }
 
 .dashboard-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .section-header {
@@ -202,12 +486,8 @@ small,
   gap: 1rem;
 }
 
-.section-header h2 {
-  margin: 0;
-}
-
 .section-header p {
-  margin: 0.25rem 0 0;
+  margin: 0.35rem 0 0;
 }
 
 .section-actions {
@@ -220,7 +500,7 @@ small,
 .dashboard-grid {
   display: grid;
   grid-template-columns: 3fr 2fr;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .dashboard-grid.secondary {
@@ -235,53 +515,72 @@ small,
   width: 100%;
   border-collapse: collapse;
   font-size: 0.95rem;
+  background: var(--surface);
+}
+
+.data-table thead th {
+  background: rgba(0, 148, 217, 0.12);
+  color: var(--primary-800);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .data-table th,
 .data-table td {
-  padding: 0.75rem;
+  padding: 0.85rem 1rem;
   text-align: left;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--neutral-150);
 }
 
-.data-table tr:hover {
-  background-color: #f1f5f9;
+.data-table tbody tr:hover {
+  background-color: rgba(0, 148, 217, 0.1);
 }
 
-.data-table tr.selected {
-  background-color: rgba(37, 99, 235, 0.12);
+.data-table tbody tr.selected {
+  background-color: rgba(0, 148, 217, 0.18);
+  box-shadow: inset 3px 0 0 0 var(--accent-red);
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
 }
 
 .data-table.compact th,
 .data-table.compact td {
-  padding: 0.5rem;
+  padding: 0.6rem 0.75rem;
 }
 
 .status {
-  padding: 0.25rem 0.5rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .status.success {
-  background: #ecfdf3;
-  color: #166534;
+  background: rgba(46, 204, 113, 0.15);
+  color: #137b3a;
 }
 
 .status.info {
-  background: #eef2ff;
-  color: #3730a3;
+  background: rgba(0, 114, 199, 0.15);
+  color: #0c3c75;
 }
 
 .status.warning {
-  background: #fff7ed;
-  color: #b45309;
+  background: rgba(240, 140, 0, 0.18);
+  color: #b35607;
 }
 
 .status.danger {
-  background: #fef2f2;
-  color: #b91c1c;
+  background: rgba(230, 57, 70, 0.16);
+  color: #a72c32;
 }
 
 .form-grid {
@@ -299,6 +598,12 @@ small,
   grid-column: 1 / -1;
 }
 
+.detail-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
 .detail-grid .full-row {
   grid-column: 1 / -1;
 }
@@ -312,75 +617,74 @@ small,
 .inline-filter {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.3rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--neutral-900);
 }
 
 .inline-filter select {
   min-width: 160px;
 }
 
-.card.success-card {
-  background: #ecfdf3;
-  border-left: 4px solid #16a34a;
-  color: #065f46;
-}
-
-.card.success-card strong {
-  color: inherit;
-}
-
-.detail-grid {
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
 .assignment-section {
-  background: #f8fafc;
-  padding: 1rem;
-  border-radius: 12px;
+  background: var(--surface-muted);
+  padding: 1.25rem;
+  border-radius: 16px;
 }
 
 .assignment-box {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   background: #ffffff;
   padding: 1rem;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  border: 1px solid rgba(11, 60, 117, 0.08);
+  box-shadow: 0 18px 30px -28px rgba(11, 60, 117, 0.25);
 }
 
-.logout {
-  background: none;
-  border: none;
-  color: #ef4444;
-}
-
-button.danger {
-  background: linear-gradient(135deg, #ef4444, #dc2626);
-  color: #ffffff;
-  box-shadow: 0 12px 24px -16px rgba(239, 68, 68, 0.6);
-}
-
-@media (max-width: 960px) {
-  .dashboard-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .dashboard-grid.secondary {
-    grid-template-columns: 1fr;
-  }
-
-  .section-header {
+@media (max-width: 1100px) {
+  .dashboard-hero {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .section-actions {
+  .dashboard-user {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 960px) {
+  .auth-card {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-brand {
+    padding: 2.5rem 2rem;
+  }
+
+  .auth-form {
+    padding: 2.5rem 2rem;
+  }
+
+  .dashboard {
+    padding: 2.5rem 1.5rem 3rem;
+  }
+
+  .dashboard-grid,
+  .dashboard-grid.secondary {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-nav {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 680px) {
+  .auth-layout {
+    padding: 2rem 1.25rem;
   }
 
   .dashboard-nav {
@@ -391,5 +695,38 @@ button.danger {
   .dashboard-nav-link {
     width: 100%;
     text-align: center;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-actions {
+    width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .auth-form {
+    padding: 2rem 1.5rem;
+  }
+
+  .dashboard {
+    padding: 2.25rem 1rem 2.75rem;
+  }
+
+  .dashboard-hero {
+    padding: 2.5rem 2rem;
+  }
+
+  .dashboard-user {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .dashboard-user button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable ChileAtiende-inspired SVG logo asset for the interface
- redesign the login screen with a brand panel, highlights, and updated copy aligned with ChileAtiende aesthetics
- refresh the dashboard header, navigation, and global styling to use the new colour palette, typography, and responsive layout refinements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d3570aed5c8321aa4474e6c2ed5b48