### PR TITLE
Add product models and stock summary

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,6 +7,7 @@ const authRoutes = require('./routes/authRoutes');
 const productRoutes = require('./routes/productRoutes');
 const dispatchGuideRoutes = require('./routes/dispatchGuideRoutes');
 const activeDirectoryRoutes = require('./routes/activeDirectoryRoutes');
+const productModelRoutes = require('./routes/productModelRoutes');
 
 const app = express();
 
@@ -24,6 +25,7 @@ app.get('/health', (req, res) => {
 
 app.use('/api/auth', authRoutes);
 app.use('/api/products', productRoutes);
+app.use('/api/product-models', productModelRoutes);
 app.use('/api/dispatch-guides', dispatchGuideRoutes);
 app.use('/api/ad', activeDirectoryRoutes);
 

--- a/backend/src/controllers/productController.js
+++ b/backend/src/controllers/productController.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const Product = require('../models/Product');
 const Assignment = require('../models/Assignment');
 const DispatchGuide = require('../models/DispatchGuide');
-const { findUserByAccount } = require('../services/activeDirectoryService');
+const ProductModel = require('../models/ProductModel');
 
 const ALLOWED_STATUSES = ['AVAILABLE', 'ASSIGNED', 'DECOMMISSIONED'];
 
@@ -42,19 +42,19 @@ function buildSearchQuery({ type, status, search }) {
 
 exports.createProduct = async (req, res) => {
   try {
-    const {
-      name,
-      description,
-      type,
-      serialNumber,
-      partNumber,
-      inventoryNumber,
-      rentalId,
-      dispatchGuideId,
-    } = req.body;
+    const { productModelId, type, serialNumber, inventoryNumber, rentalId, dispatchGuideId } = req.body;
 
-    if (!name || !type || !serialNumber || !partNumber) {
-      return res.status(400).json({ message: 'Nombre, tipo, número de serie y número de parte son obligatorios.' });
+    if (!productModelId || !type || !serialNumber) {
+      return res.status(400).json({ message: 'Modelo de producto, tipo y número de serie son obligatorios.' });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(productModelId)) {
+      return res.status(400).json({ message: 'Identificador de modelo de producto inválido.' });
+    }
+
+    const productModel = await ProductModel.findById(productModelId);
+    if (!productModel) {
+      return res.status(404).json({ message: 'Modelo de producto no encontrado.' });
     }
 
     if (!['PURCHASED', 'RENTAL'].includes(type)) {
@@ -84,18 +84,21 @@ exports.createProduct = async (req, res) => {
     }
 
     const product = await Product.create({
-      name,
-      description,
+      productModel: productModel._id,
+      name: productModel.name,
+      description: productModel.description,
       type,
       serialNumber,
-      partNumber,
+      partNumber: productModel.partNumber,
       inventoryNumber: type === 'PURCHASED' ? inventoryNumber || null : undefined,
       rentalId: type === 'RENTAL' ? rentalId : undefined,
       dispatchGuide: dispatchGuide._id,
       createdBy: req.user._id,
     });
 
-    res.status(201).json(product);
+    const populated = await product.populate('productModel');
+
+    res.status(201).json(populated);
   } catch (error) {
     console.error('createProduct error', error);
     res.status(500).json({ message: 'No se pudo crear el producto.' });
@@ -107,6 +110,7 @@ exports.listProducts = async (req, res) => {
     const query = buildSearchQuery(req.query);
     const products = await Product.find(query)
       .populate('dispatchGuide')
+      .populate('productModel')
       .populate('decommissionedBy', 'name email role')
       .sort({ createdAt: -1 });
     res.json(products);
@@ -124,6 +128,7 @@ exports.getProduct = async (req, res) => {
 
     const product = await Product.findById(req.params.id)
       .populate('dispatchGuide')
+      .populate('productModel')
       .populate('decommissionedBy', 'name email role');
     if (!product) {
       return res.status(404).json({ message: 'Producto no encontrado.' });
@@ -143,13 +148,12 @@ exports.updateProduct = async (req, res) => {
     }
 
     const allowedUpdates = [
-      'name',
       'description',
       'serialNumber',
-      'partNumber',
       'inventoryNumber',
       'rentalId',
       'dispatchGuideId',
+      'productModelId',
     ];
 
     const updates = Object.keys(req.body).filter((key) => allowedUpdates.includes(key));
@@ -177,6 +181,19 @@ exports.updateProduct = async (req, res) => {
           return res.status(404).json({ message: 'Guía de despacho no encontrada.' });
         }
         product.dispatchGuide = dispatchGuide._id;
+      } else if (key === 'productModelId') {
+        const productModelId = req.body.productModelId;
+        if (!productModelId || !mongoose.Types.ObjectId.isValid(productModelId)) {
+          return res.status(400).json({ message: 'Identificador de modelo de producto inválido.' });
+        }
+        const productModel = await ProductModel.findById(productModelId);
+        if (!productModel) {
+          return res.status(404).json({ message: 'Modelo de producto no encontrado.' });
+        }
+        product.productModel = productModel._id;
+        product.name = productModel.name;
+        product.partNumber = productModel.partNumber;
+        product.description = productModel.description;
       } else {
         product[key] = req.body[key];
       }
@@ -184,7 +201,9 @@ exports.updateProduct = async (req, res) => {
 
     await product.save();
 
-    res.json(product);
+    const populated = await product.populate('productModel');
+
+    res.json(populated);
   } catch (error) {
     console.error('updateProduct error', error);
     res.status(500).json({ message: 'No se pudo actualizar el producto.' });
@@ -197,10 +216,10 @@ exports.assignProduct = async (req, res) => {
       return res.status(400).json({ message: 'Identificador inválido.' });
     }
 
-    const { assignedTo, assignedToAdAccount, location, assignmentDate, notes } = req.body;
+    const { assignedTo, location, assignmentDate, notes } = req.body;
 
-    if (!assignedTo || !assignedToAdAccount || !location) {
-      return res.status(400).json({ message: 'Usuario, cuenta de Active Directory y ubicación son obligatorios.' });
+    if (!assignedTo || !location) {
+      return res.status(400).json({ message: 'Usuario y ubicación son obligatorios.' });
     }
 
     const product = await Product.findById(req.params.id);
@@ -212,18 +231,12 @@ exports.assignProduct = async (req, res) => {
       return res.status(400).json({ message: 'El producto está dado de baja y no puede asignarse.' });
     }
 
-    const adUser = findUserByAccount(assignedToAdAccount);
-    if (!adUser) {
-      return res.status(400).json({ message: 'La cuenta de Active Directory no existe en el directorio simulado.' });
-    }
-
     const effectiveAssignmentDate = assignmentDate ? new Date(assignmentDate) : new Date();
 
     const assignment = await Assignment.create({
       product: product._id,
       action: 'ASSIGN',
       assignedTo,
-      assignedToAdAccount: adUser.adAccount,
       location,
       assignmentDate: effectiveAssignmentDate,
       performedBy: req.user._id,
@@ -232,7 +245,6 @@ exports.assignProduct = async (req, res) => {
 
     product.currentAssignment = {
       assignedTo,
-      assignedToAdAccount: adUser.adAccount,
       location,
       assignmentDate: effectiveAssignmentDate,
     };
@@ -244,7 +256,9 @@ exports.assignProduct = async (req, res) => {
 
     await product.save();
 
-    res.json({ product, assignment });
+    const updatedProduct = await product.populate('dispatchGuide').populate('productModel');
+
+    res.json({ product: updatedProduct, assignment });
   } catch (error) {
     console.error('assignProduct error', error);
     res.status(500).json({ message: 'No se pudo asignar el producto.' });
@@ -278,7 +292,6 @@ exports.unassignProduct = async (req, res) => {
       product: product._id,
       action: 'UNASSIGN',
       assignedTo: product.currentAssignment.assignedTo,
-      assignedToAdAccount: product.currentAssignment.assignedToAdAccount,
       location: location || product.currentAssignment.location,
       assignmentDate: effectiveAssignmentDate,
       performedBy: req.user._id,
@@ -289,7 +302,9 @@ exports.unassignProduct = async (req, res) => {
     product.status = 'AVAILABLE';
     await product.save();
 
-    res.json({ product, assignment });
+    const updatedProduct = await product.populate('dispatchGuide').populate('productModel');
+
+    res.json({ product: updatedProduct, assignment });
   } catch (error) {
     console.error('unassignProduct error', error);
     res.status(500).json({ message: 'No se pudo desasignar el producto.' });
@@ -381,5 +396,78 @@ exports.getAssignmentHistory = async (req, res) => {
   } catch (error) {
     console.error('getAssignmentHistory error', error);
     res.status(500).json({ message: 'No se pudo obtener el historial de asignaciones.' });
+  }
+};
+
+exports.getStockSummary = async (req, res) => {
+  try {
+    const summary = await Product.aggregate([
+      {
+        $group: {
+          _id: {
+            productModel: '$productModel',
+            name: '$name',
+            partNumber: '$partNumber',
+          },
+          description: { $first: '$description' },
+          total: { $sum: 1 },
+          available: {
+            $sum: { $cond: [{ $eq: ['$status', 'AVAILABLE'] }, 1, 0] },
+          },
+          assigned: {
+            $sum: { $cond: [{ $eq: ['$status', 'ASSIGNED'] }, 1, 0] },
+          },
+          decommissioned: {
+            $sum: { $cond: [{ $eq: ['$status', 'DECOMMISSIONED'] }, 1, 0] },
+          },
+          purchased: {
+            $sum: { $cond: [{ $eq: ['$type', 'PURCHASED'] }, 1, 0] },
+          },
+          rental: {
+            $sum: { $cond: [{ $eq: ['$type', 'RENTAL'] }, 1, 0] },
+          },
+        },
+      },
+      {
+        $lookup: {
+          from: 'productmodels',
+          localField: '_id.productModel',
+          foreignField: '_id',
+          as: 'productModel',
+        },
+      },
+      {
+        $unwind: {
+          path: '$productModel',
+          preserveNullAndEmptyArrays: true,
+        },
+      },
+      {
+        $project: {
+          productModelId: { $ifNull: ['$productModel._id', '$_id.productModel'] },
+          name: { $ifNull: ['$productModel.name', '$_id.name'] },
+          partNumber: { $ifNull: ['$productModel.partNumber', '$_id.partNumber'] },
+          description: { $ifNull: ['$productModel.description', '$description'] },
+          totals: {
+            total: '$total',
+            available: '$available',
+            assigned: '$assigned',
+            decommissioned: '$decommissioned',
+          },
+          typeBreakdown: {
+            purchased: '$purchased',
+            rental: '$rental',
+          },
+        },
+      },
+      {
+        $sort: { name: 1, partNumber: 1 },
+      },
+    ]);
+
+    res.json(summary);
+  } catch (error) {
+    console.error('getStockSummary error', error);
+    res.status(500).json({ message: 'No se pudo obtener el resumen de stock.' });
   }
 };

--- a/backend/src/controllers/productModelController.js
+++ b/backend/src/controllers/productModelController.js
@@ -1,0 +1,45 @@
+const mongoose = require('mongoose');
+const ProductModel = require('../models/ProductModel');
+
+exports.createProductModel = async (req, res) => {
+  try {
+    const { name, description, partNumber } = req.body;
+
+    if (!name || !partNumber) {
+      return res.status(400).json({ message: 'Nombre y número de parte son obligatorios.' });
+    }
+
+    const normalizedPartNumber = partNumber.trim();
+    const existing = await ProductModel.findOne({ partNumber: normalizedPartNumber });
+    if (existing) {
+      return res
+        .status(409)
+        .json({ message: 'Ya existe un modelo de producto con ese número de parte.' });
+    }
+
+    const productModel = await ProductModel.create({
+      name: name.trim(),
+      description: description ? description.trim() : undefined,
+      partNumber: normalizedPartNumber,
+      createdBy: req.user._id,
+    });
+
+    res.status(201).json(productModel);
+  } catch (error) {
+    console.error('createProductModel error', error);
+    if (error instanceof mongoose.Error.ValidationError) {
+      return res.status(400).json({ message: 'Datos inválidos para crear el modelo de producto.' });
+    }
+    res.status(500).json({ message: 'No se pudo crear el modelo de producto.' });
+  }
+};
+
+exports.listProductModels = async (req, res) => {
+  try {
+    const models = await ProductModel.find().sort({ name: 1, partNumber: 1 });
+    res.json(models);
+  } catch (error) {
+    console.error('listProductModels error', error);
+    res.status(500).json({ message: 'No se pudieron obtener los modelos de producto.' });
+  }
+};

--- a/backend/src/models/Assignment.js
+++ b/backend/src/models/Assignment.js
@@ -7,7 +7,6 @@ const assignmentSchema = new Schema(
     product: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
     action: { type: String, enum: ['ASSIGN', 'UNASSIGN'], required: true },
     assignedTo: { type: String, required: true },
-    assignedToAdAccount: { type: String, required: true },
     location: { type: String, required: true },
     assignmentDate: { type: Date, required: true },
     performedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },

--- a/backend/src/models/Product.js
+++ b/backend/src/models/Product.js
@@ -5,7 +5,6 @@ const { Schema } = mongoose;
 const assignmentSnapshotSchema = new Schema(
   {
     assignedTo: String,
-    assignedToAdAccount: String,
     location: String,
     assignmentDate: Date,
   },
@@ -14,6 +13,7 @@ const assignmentSnapshotSchema = new Schema(
 
 const productSchema = new Schema(
   {
+    productModel: { type: Schema.Types.ObjectId, ref: 'ProductModel' },
     name: { type: String, required: true, trim: true },
     description: { type: String, trim: true },
     type: {

--- a/backend/src/models/ProductModel.js
+++ b/backend/src/models/ProductModel.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const productModelSchema = new Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    description: { type: String, trim: true },
+    partNumber: { type: String, required: true, trim: true },
+    createdBy: { type: Schema.Types.ObjectId, ref: 'User' },
+  },
+  { timestamps: true }
+);
+
+productModelSchema.index({ name: 1, partNumber: 1 }, { unique: true });
+
+module.exports = mongoose.model('ProductModel', productModelSchema);

--- a/backend/src/routes/productModelRoutes.js
+++ b/backend/src/routes/productModelRoutes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const productModelController = require('../controllers/productModelController');
+const { authenticate, authorizeRoles } = require('../middleware/auth');
+
+const router = express.Router();
+
+router.get('/', authenticate, productModelController.listProductModels);
+
+router.post(
+  '/',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  productModelController.createProductModel
+);
+
+module.exports = router;

--- a/backend/src/routes/productRoutes.js
+++ b/backend/src/routes/productRoutes.js
@@ -12,6 +12,7 @@ router.post(
 );
 
 router.get('/', authenticate, productController.listProducts);
+router.get('/stock', authenticate, productController.getStockSummary);
 router.get('/:id', authenticate, productController.getProduct);
 
 router.put(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,8 @@ import AssignmentsPage from './pages/AssignmentsPage';
 import ProductEntryPage from './pages/ProductEntryPage';
 import DispatchGuidesPage from './pages/DispatchGuidesPage';
 import ProductDecommissionPage from './pages/ProductDecommissionPage';
+import StockConsultPage from './pages/StockConsultPage';
+import ProductCatalogPage from './pages/ProductCatalogPage';
 
 function App() {
   const { isAuthenticated } = useAuth();
@@ -27,8 +29,10 @@ function App() {
         }
       >
         <Route index element={<InventoryPage />} />
+        <Route path="stock" element={<StockConsultPage />} />
         <Route path="asignaciones" element={<AssignmentsPage />} />
         <Route path="productos/nuevo" element={<ProductEntryPage />} />
+        <Route path="productos/catalogo" element={<ProductCatalogPage />} />
         <Route path="guias" element={<DispatchGuidesPage />} />
         <Route path="bajas" element={<ProductDecommissionPage />} />
       </Route>

--- a/frontend/src/components/AssignmentHistory.jsx
+++ b/frontend/src/components/AssignmentHistory.jsx
@@ -10,7 +10,6 @@ function AssignmentHistory({ history, loading }) {
             <tr>
               <th>Acción</th>
               <th>Usuario asignado</th>
-              <th>Cuenta AD</th>
               <th>Ubicación</th>
               <th>Fecha</th>
               <th>Registrado por</th>
@@ -20,14 +19,14 @@ function AssignmentHistory({ history, loading }) {
           <tbody>
             {loading && (
               <tr>
-                <td colSpan={7} className="muted">
+                <td colSpan={6} className="muted">
                   Cargando movimientos...
                 </td>
               </tr>
             )}
             {!loading && history.length === 0 && (
               <tr>
-                <td colSpan={7} className="muted">
+                <td colSpan={6} className="muted">
                   No hay movimientos registrados.
                 </td>
               </tr>
@@ -40,7 +39,6 @@ function AssignmentHistory({ history, loading }) {
                   </span>
                 </td>
                 <td>{item.assignedTo}</td>
-                <td>{item.assignedToAdAccount}</td>
                 <td>{item.location}</td>
                 <td>{new Date(item.assignmentDate).toLocaleString('es-CL')}</td>
                 <td>{item.performedBy?.name || '—'}</td>

--- a/frontend/src/components/ProductAssignmentPanel.jsx
+++ b/frontend/src/components/ProductAssignmentPanel.jsx
@@ -3,7 +3,6 @@ import { getProductStatusBadge, getProductStatusLabel, isDecommissioned } from '
 
 const emptyState = {
   assignedTo: '',
-  assignedToAdAccount: '',
   location: '',
   assignmentDate: '',
   notes: '',
@@ -14,7 +13,6 @@ function ProductAssignmentPanel({
   onAssign,
   onUnassign,
   isProcessing,
-  adUsers,
   canManage,
 }) {
   const [values, setValues] = useState(emptyState);
@@ -50,7 +48,7 @@ function ProductAssignmentPanel({
       return;
     }
 
-    if (!values.assignedTo || !values.assignedToAdAccount || !values.location) {
+    if (!values.assignedTo || !values.location) {
       setError('Completa los campos obligatorios.');
       return;
     }
@@ -58,7 +56,6 @@ function ProductAssignmentPanel({
     try {
       await onAssign({
         assignedTo: values.assignedTo,
-        assignedToAdAccount: values.assignedToAdAccount,
         location: values.location,
         assignmentDate: values.assignmentDate || undefined,
         notes: values.notes || undefined,
@@ -90,6 +87,9 @@ function ProductAssignmentPanel({
 
   const isProductDecommissioned = product ? isDecommissioned(product.status) : false;
   const currentAssignment = product.currentAssignment;
+  const productName = product.productModel?.name || product.name;
+  const productPartNumber = product.productModel?.partNumber || product.partNumber;
+  const productDescription = product.productModel?.description ?? product.description ?? '';
 
   return (
     <div className="card">
@@ -103,13 +103,13 @@ function ProductAssignmentPanel({
 
       <div className="detail-grid">
         <div>
-          <strong>Nombre:</strong> {product.name}
+          <strong>Nombre:</strong> {productName}
         </div>
         <div>
           <strong>N° serie:</strong> {product.serialNumber}
         </div>
         <div>
-          <strong>N° parte:</strong> {product.partNumber}
+          <strong>N° parte:</strong> {productPartNumber}
         </div>
         <div>
           <strong>{product.type === 'PURCHASED' ? 'Inventario' : 'ID arriendo'}:</strong>{' '}
@@ -124,6 +124,11 @@ function ProductAssignmentPanel({
             {getProductStatusLabel(product.status)}
           </span>
         </div>
+        {productDescription && (
+          <div className="full-width muted small-text">
+            <strong>Descripción:</strong> {productDescription}
+          </div>
+        )}
         {isProductDecommissioned && product.decommissionReason && (
           <div className="muted small-text">
             Motivo de baja: {product.decommissionReason}
@@ -136,7 +141,7 @@ function ProductAssignmentPanel({
         {currentAssignment ? (
           <div className="assignment-box">
             <p>
-              <strong>{currentAssignment.assignedTo}</strong> · {currentAssignment.assignedToAdAccount}
+              <strong>{currentAssignment.assignedTo}</strong>
             </p>
             <p className="muted">
               Ubicación: {currentAssignment.location} ·{' '}
@@ -165,9 +170,9 @@ function ProductAssignmentPanel({
         {isProductDecommissioned ? (
           <p className="muted">Este producto está dado de baja y no puede asignarse.</p>
         ) : canManage ? (
-          <form className="form-grid" onSubmit={handleAssign}>
-            <label>
-              Usuario
+            <form className="form-grid" onSubmit={handleAssign}>
+              <label>
+                Usuario
               <input
                 name="assignedTo"
                 value={values.assignedTo}
@@ -175,27 +180,9 @@ function ProductAssignmentPanel({
                 placeholder="Nombre del colaborador"
                 required
               />
-            </label>
-            <label>
-              Cuenta AD
-              <input
-                list="ad-users"
-                name="assignedToAdAccount"
-                value={values.assignedToAdAccount}
-                onChange={handleChange}
-                placeholder="Cuenta de dominio"
-                required
-              />
-              <datalist id="ad-users">
-                {adUsers.map((user) => (
-                  <option key={user.id} value={user.adAccount}>
-                    {user.displayName}
-                  </option>
-                ))}
-              </datalist>
-            </label>
-            <label>
-              Ubicación
+              </label>
+              <label>
+                Ubicación
               <input
                 name="location"
                 value={values.location}
@@ -244,7 +231,6 @@ function ProductAssignmentPanel({
 
 ProductAssignmentPanel.defaultProps = {
   product: null,
-  adUsers: [],
   isProcessing: false,
   onAssign: () => Promise.resolve(),
   onUnassign: () => Promise.resolve(),

--- a/frontend/src/components/ProductTable.jsx
+++ b/frontend/src/components/ProductTable.jsx
@@ -40,6 +40,8 @@ function ProductTable({ products, onSelect, selectedProductId }) {
               </tr>
             )}
             {products.map((product) => {
+              const productName = product.productModel?.name || product.name;
+              const productPartNumber = product.productModel?.partNumber || product.partNumber;
               const isSelected = product._id === selectedProductId;
               return (
                 <tr
@@ -47,10 +49,10 @@ function ProductTable({ products, onSelect, selectedProductId }) {
                   className={isSelected ? 'selected' : ''}
                   onClick={() => onSelect(product._id)}
                 >
-                  <td>{product.name}</td>
+                  <td>{productName}</td>
                   <td>{formatType(product.type)}</td>
                   <td>{product.serialNumber}</td>
-                  <td>{product.partNumber}</td>
+                  <td>{productPartNumber}</td>
                   <td>
                     {product.type === 'PURCHASED'
                       ? product.inventoryNumber || '—'

--- a/frontend/src/pages/AssignmentsPage.jsx
+++ b/frontend/src/pages/AssignmentsPage.jsx
@@ -13,8 +13,6 @@ function AssignmentsPage() {
   const [assignmentHistory, setAssignmentHistory] = useState([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [assignmentProcessing, setAssignmentProcessing] = useState(false);
-  const [adUsers, setAdUsers] = useState([]);
-  const [adError, setAdError] = useState('');
 
   const canManage = hasRole('ADMIN', 'MANAGER');
 
@@ -59,27 +57,11 @@ function AssignmentsPage() {
     [request]
   );
 
-  const loadAdUsers = useCallback(async () => {
-    if (!canManage) {
-      setAdUsers([]);
-      return;
-    }
-    try {
-      const users = await request('/ad/users');
-      setAdUsers(users);
-      setAdError('');
-    } catch (error) {
-      setAdError('No se pudieron sincronizar los usuarios de Active Directory.');
-      setAdUsers([]);
-    }
-  }, [canManage, request]);
-
   useEffect(() => {
     if (canManage) {
       loadProducts();
-      loadAdUsers();
     }
-  }, [loadProducts, loadAdUsers, canManage]);
+  }, [loadProducts, canManage]);
 
   useEffect(() => {
     if (selectedProductId && canManage) {
@@ -174,12 +156,6 @@ function AssignmentsPage() {
         </div>
       )}
 
-      {adError && (
-        <div className="card">
-          <strong>Advertencia:</strong> {adError}
-        </div>
-      )}
-
       <div className="dashboard-grid">
         <ProductTable
           products={products}
@@ -192,7 +168,6 @@ function AssignmentsPage() {
             onAssign={handleAssignProduct}
             onUnassign={handleUnassignProduct}
             isProcessing={assignmentProcessing}
-            adUsers={adUsers}
             canManage={canManage}
           />
           <AssignmentHistory history={assignmentHistory} loading={historyLoading} />

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -5,8 +5,10 @@ import chileAtiendeLogo from '../assets/chileatiende-logo.svg';
 
 const NAV_ITEMS = [
   { to: '.', label: 'Inventario', end: true },
+  { to: 'stock', label: 'Consultar stock' },
   { to: 'asignaciones', label: 'Asignaciones', requiresManage: true },
   { to: 'productos/nuevo', label: 'Ingresar producto', requiresManage: true },
+  { to: 'productos/catalogo', label: 'Catálogo de productos', requiresManage: true },
   { to: 'guias', label: 'Guías de despacho', requiresManage: true },
   { to: 'bajas', label: 'Bajas de inventario', requiresManage: true },
 ];

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -75,6 +75,12 @@ function InventoryPage() {
     [products, selectedProductId]
   );
 
+  const selectedProductName = selectedProduct?.productModel?.name || selectedProduct?.name;
+  const selectedProductPartNumber =
+    selectedProduct?.productModel?.partNumber || selectedProduct?.partNumber;
+  const selectedProductDescription =
+    selectedProduct?.productModel?.description ?? selectedProduct?.description;
+
   const handleFilterChange = (event) => {
     const value = event.target.value;
     setStatusFilter(value);
@@ -171,7 +177,7 @@ function InventoryPage() {
             <>
               <div className="detail-grid">
                 <div>
-                  <strong>Nombre:</strong> {selectedProduct.name}
+                  <strong>Nombre:</strong> {selectedProductName}
                 </div>
                 <div>
                   <strong>Tipo:</strong> {formatType(selectedProduct.type)}
@@ -180,7 +186,7 @@ function InventoryPage() {
                   <strong>N° serie:</strong> {selectedProduct.serialNumber}
                 </div>
                 <div>
-                  <strong>N° parte:</strong> {selectedProduct.partNumber}
+                  <strong>N° parte:</strong> {selectedProductPartNumber}
                 </div>
                 {selectedProduct.type === 'PURCHASED' ? (
                   <div>
@@ -194,9 +200,9 @@ function InventoryPage() {
                 <div>
                   <strong>Guía:</strong> {selectedProduct.dispatchGuide?.guideNumber || '—'}
                 </div>
-                {selectedProduct.description && (
+                {selectedProductDescription && (
                   <div className="full-row">
-                    <strong>Descripción:</strong> {selectedProduct.description}
+                    <strong>Descripción:</strong> {selectedProductDescription}
                   </div>
                 )}
                 <div className="full-row">
@@ -210,8 +216,7 @@ function InventoryPage() {
               {selectedProduct.status === 'ASSIGNED' && selectedProduct.currentAssignment && (
                 <div className="assignment-box">
                   <p>
-                    <strong>{selectedProduct.currentAssignment.assignedTo}</strong> ·{' '}
-                    {selectedProduct.currentAssignment.assignedToAdAccount}
+                    <strong>{selectedProduct.currentAssignment.assignedTo}</strong>
                   </p>
                   <p className="muted">
                     Ubicación: {selectedProduct.currentAssignment.location} ·{' '}

--- a/frontend/src/pages/ProductCatalogPage.jsx
+++ b/frontend/src/pages/ProductCatalogPage.jsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+const initialFormState = {
+  name: '',
+  partNumber: '',
+  description: '',
+};
+
+function ProductCatalogPage() {
+  const { request, hasRole } = useAuth();
+  const canManage = hasRole('ADMIN', 'MANAGER');
+
+  const [models, setModels] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [formValues, setFormValues] = useState(initialFormState);
+  const [formError, setFormError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const sortedModels = useMemo(
+    () =>
+      [...models].sort((a, b) => {
+        const nameComparison = a.name.localeCompare(b.name, 'es');
+        if (nameComparison !== 0) {
+          return nameComparison;
+        }
+        return a.partNumber.localeCompare(b.partNumber, 'es');
+      }),
+    [models]
+  );
+
+  const loadModels = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await request('/product-models');
+      setModels(data);
+    } catch (err) {
+      setModels([]);
+      setError(err.message || 'No se pudieron obtener los modelos registrados.');
+    } finally {
+      setLoading(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    if (canManage) {
+      loadModels();
+    }
+  }, [canManage, loadModels]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setFormError('');
+
+    if (!formValues.name.trim() || !formValues.partNumber.trim()) {
+      setFormError('Completa el nombre y el número de parte.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await request('/product-models', {
+        method: 'POST',
+        data: {
+          name: formValues.name.trim(),
+          partNumber: formValues.partNumber.trim(),
+          description: formValues.description.trim() || undefined,
+        },
+      });
+      setFormValues(initialFormState);
+      await loadModels();
+    } catch (err) {
+      setFormError(err.message || 'No se pudo registrar el modelo.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!canManage) {
+    return (
+      <section className="dashboard-section">
+        <div className="card">
+          <h2>Catálogo de productos</h2>
+          <p className="muted">
+            Solo los administradores o encargados pueden administrar el catálogo de productos.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Catálogo de productos</h2>
+          <p className="muted">
+            Define los modelos disponibles para evitar duplicidades al registrar unidades nuevas.
+          </p>
+        </div>
+        <div className="section-actions">
+          <button type="button" className="secondary" onClick={loadModels} disabled={loading}>
+            {loading ? 'Actualizando...' : 'Actualizar catálogo'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="card">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <div className="dashboard-grid secondary">
+        <form className="card" onSubmit={handleSubmit}>
+          <div className="card-header">
+            <h3>Nuevo modelo</h3>
+            <p className="muted">
+              Ingresa el nombre y número de parte del producto que se utilizará al registrar unidades.
+            </p>
+          </div>
+          <div className="form-grid">
+            <label>
+              Nombre
+              <input
+                name="name"
+                value={formValues.name}
+                onChange={handleChange}
+                required
+              />
+            </label>
+            <label>
+              Número de parte
+              <input
+                name="partNumber"
+                value={formValues.partNumber}
+                onChange={handleChange}
+                required
+              />
+            </label>
+            <label className="full-width">
+              Descripción
+              <textarea
+                name="description"
+                value={formValues.description}
+                onChange={handleChange}
+                rows={3}
+                placeholder="Opcional"
+              />
+            </label>
+          </div>
+          {formError && <p className="error">{formError}</p>}
+          <button type="submit" className="primary" disabled={submitting}>
+            {submitting ? 'Guardando...' : 'Registrar modelo'}
+          </button>
+          <p className="muted small-text">
+            Luego podrás seleccionar estos modelos al ingresar unidades en{' '}
+            <Link to="/productos/nuevo">Ingresar producto</Link>.
+          </p>
+        </form>
+
+        <div className="card">
+          <div className="card-header">
+            <h3>Modelos registrados</h3>
+            <p className="muted">Listado de productos disponibles para asignar en el inventario.</p>
+          </div>
+          <div className="table-responsive">
+            <table className="data-table compact">
+              <thead>
+                <tr>
+                  <th>Nombre</th>
+                  <th>N° de parte</th>
+                  <th>Descripción</th>
+                  <th>Creado</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading && (
+                  <tr>
+                    <td colSpan={4} className="muted">
+                      Cargando catálogo...
+                    </td>
+                  </tr>
+                )}
+                {!loading && sortedModels.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="muted">
+                      Aún no hay modelos registrados.
+                    </td>
+                  </tr>
+                )}
+                {sortedModels.map((model) => (
+                  <tr key={model._id}>
+                    <td>{model.name}</td>
+                    <td>{model.partNumber}</td>
+                    <td>{model.description || '—'}</td>
+                    <td>{new Date(model.createdAt).toLocaleDateString('es-CL')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default ProductCatalogPage;

--- a/frontend/src/pages/ProductDecommissionPage.jsx
+++ b/frontend/src/pages/ProductDecommissionPage.jsx
@@ -62,6 +62,8 @@ function ProductDecommissionPage() {
     [activeProducts, selectedProductId]
   );
 
+  const selectedProductName = selectedProduct?.productModel?.name || selectedProduct?.name;
+
   useEffect(() => {
     setReason('');
     setFormError('');
@@ -153,7 +155,7 @@ function ProductDecommissionPage() {
           {selectedProduct && (
             <form className="form-grid" onSubmit={handleSubmit}>
               <div className="full-width">
-                <strong>{selectedProduct.name}</strong>{' '}
+                <strong>{selectedProductName}</strong>{' '}
                 <span className="muted">({selectedProduct.serialNumber})</span>
               </div>
               <div className="full-width">

--- a/frontend/src/pages/ProductEntryPage.jsx
+++ b/frontend/src/pages/ProductEntryPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import ProductForm from '../components/ProductForm';
 import { useAuth } from '../hooks/useAuth';
 
@@ -7,6 +8,9 @@ function ProductEntryPage() {
   const [dispatchGuides, setDispatchGuides] = useState([]);
   const [loadingGuides, setLoadingGuides] = useState(false);
   const [guidesError, setGuidesError] = useState('');
+  const [productModels, setProductModels] = useState([]);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [modelsError, setModelsError] = useState('');
   const [creatingProduct, setCreatingProduct] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
 
@@ -26,11 +30,26 @@ function ProductEntryPage() {
     }
   }, [request]);
 
+  const loadProductModels = useCallback(async () => {
+    setLoadingModels(true);
+    setModelsError('');
+    try {
+      const models = await request('/product-models');
+      setProductModels(models);
+    } catch (error) {
+      setModelsError(error.message || 'No se pudieron obtener los modelos de producto.');
+      setProductModels([]);
+    } finally {
+      setLoadingModels(false);
+    }
+  }, [request]);
+
   useEffect(() => {
     if (canManage) {
       loadDispatchGuides();
+      loadProductModels();
     }
-  }, [loadDispatchGuides, canManage]);
+  }, [loadDispatchGuides, loadProductModels, canManage]);
 
   const handleCreateProduct = useCallback(
     async (payload) => {
@@ -83,6 +102,14 @@ function ProductEntryPage() {
           >
             {loadingGuides ? 'Actualizando...' : 'Actualizar guías'}
           </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={loadProductModels}
+            disabled={loadingModels}
+          >
+            {loadingModels ? 'Actualizando...' : 'Actualizar modelos'}
+          </button>
         </div>
       </div>
 
@@ -92,9 +119,22 @@ function ProductEntryPage() {
         </div>
       )}
 
+      {modelsError && (
+        <div className="card">
+          <strong>Error:</strong> {modelsError}
+        </div>
+      )}
+
       {successMessage && (
         <div className="card success-card">
           <strong>Éxito:</strong> {successMessage}
+        </div>
+      )}
+
+      {productModels.length === 0 && !loadingModels && (
+        <div className="card">
+          <strong>Atención:</strong> Aún no hay modelos registrados. Visita el{' '}
+          <Link to="/productos/catalogo">catálogo de productos</Link> para crear uno antes de continuar.
         </div>
       )}
 
@@ -102,6 +142,7 @@ function ProductEntryPage() {
         onSubmit={handleCreateProduct}
         dispatchGuides={dispatchGuides}
         isSubmitting={creatingProduct}
+        productModels={productModels}
       />
     </section>
   );

--- a/frontend/src/pages/StockConsultPage.jsx
+++ b/frontend/src/pages/StockConsultPage.jsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
+
+function StockConsultPage() {
+  const { request } = useAuth();
+  const [summary, setSummary] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const loadSummary = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await request('/products/stock');
+      setSummary(data);
+    } catch (err) {
+      setSummary([]);
+      setError(err.message || 'No se pudo obtener el resumen de stock.');
+    } finally {
+      setLoading(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  const totals = useMemo(() => {
+    if (!summary.length) {
+      return null;
+    }
+    return summary.reduce(
+      (acc, item) => ({
+        total: acc.total + item.totals.total,
+        available: acc.available + item.totals.available,
+        assigned: acc.assigned + item.totals.assigned,
+        decommissioned: acc.decommissioned + item.totals.decommissioned,
+        purchased: acc.purchased + item.typeBreakdown.purchased,
+        rental: acc.rental + item.typeBreakdown.rental,
+      }),
+      { total: 0, available: 0, assigned: 0, decommissioned: 0, purchased: 0, rental: 0 }
+    );
+  }, [summary]);
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Consultar stock</h2>
+          <p className="muted">
+            Visualiza la cantidad de unidades por modelo de producto sin considerar los números de serie.
+          </p>
+        </div>
+        <div className="section-actions">
+          <button type="button" className="secondary" onClick={loadSummary} disabled={loading}>
+            {loading ? 'Actualizando...' : 'Actualizar'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="card">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-header">
+          <h3>Resumen de unidades</h3>
+          <p className="muted">
+            Totales agrupados por modelo de producto, con el estado y tipo de adquisición de cada unidad.
+          </p>
+        </div>
+        <div className="table-responsive">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Producto</th>
+                <th>N° de parte</th>
+                <th>Total</th>
+                <th>Disponibles</th>
+                <th>Asignados</th>
+                <th>Dados de baja</th>
+                <th>Compras</th>
+                <th>Arriendos</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <tr>
+                  <td colSpan={8} className="muted">
+                    Cargando resumen...
+                  </td>
+                </tr>
+              )}
+              {!loading && summary.length === 0 && (
+                <tr>
+                  <td colSpan={8} className="muted">
+                    Aún no hay unidades registradas.
+                  </td>
+                </tr>
+              )}
+              {summary.map((item) => (
+                <tr key={`${item.productModelId || 'sin-modelo'}-${item.partNumber || 'sin-parte'}`}>
+                  <td>
+                    <strong>{item.name}</strong>
+                    {item.description && <div className="muted small-text">{item.description}</div>}
+                  </td>
+                  <td>{item.partNumber || '—'}</td>
+                  <td>{item.totals.total}</td>
+                  <td>{item.totals.available}</td>
+                  <td>{item.totals.assigned}</td>
+                  <td>{item.totals.decommissioned}</td>
+                  <td>{item.typeBreakdown.purchased}</td>
+                  <td>{item.typeBreakdown.rental}</td>
+                </tr>
+              ))}
+              {totals && summary.length > 0 && (
+                <tr>
+                  <td colSpan={2}>Totales generales</td>
+                  <td>{totals.total}</td>
+                  <td>{totals.available}</td>
+                  <td>{totals.assigned}</td>
+                  <td>{totals.decommissioned}</td>
+                  <td>{totals.purchased}</td>
+                  <td>{totals.rental}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default StockConsultPage;


### PR DESCRIPTION
## Summary
- add a catalog of product models and tie new product creation/updates to those definitions while exposing a stock summary API
- update assignment persistence to drop the Active Directory requirement and surface product model data throughout inventory views
- introduce catalog and stock consultation pages plus adapt the product entry form to select existing models

## Testing
- npm run build (frontend)
- npm test (backend)


------
https://chatgpt.com/codex/tasks/task_b_68d35a2dea688321a79b96358ccd33d5