### PR TITLE
Add user administration module and search filters

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,6 +8,7 @@ const productRoutes = require('./routes/productRoutes');
 const dispatchGuideRoutes = require('./routes/dispatchGuideRoutes');
 const activeDirectoryRoutes = require('./routes/activeDirectoryRoutes');
 const productModelRoutes = require('./routes/productModelRoutes');
+const userRoutes = require('./routes/userRoutes');
 
 const app = express();
 
@@ -28,6 +29,7 @@ app.use('/api/products', productRoutes);
 app.use('/api/product-models', productModelRoutes);
 app.use('/api/dispatch-guides', dispatchGuideRoutes);
 app.use('/api/ad', activeDirectoryRoutes);
+app.use('/api/users', userRoutes);
 
 app.use((err, req, res, next) => {
   console.error(err);

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,0 +1,111 @@
+const User = require('../models/User');
+const { hashPassword } = require('../utils/password');
+
+const ALLOWED_ROLES = ['ADMIN', 'MANAGER', 'VIEWER'];
+
+function resolveRole(role) {
+  if (!role) {
+    return 'VIEWER';
+  }
+  const normalized = String(role).toUpperCase();
+  if (!ALLOWED_ROLES.includes(normalized)) {
+    return 'VIEWER';
+  }
+  return normalized;
+}
+
+function formatAdAccount(value) {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = String(value).trim();
+  return trimmed || undefined;
+}
+
+exports.listUsers = async (req, res) => {
+  try {
+    const users = await User.find().sort({ createdAt: -1 });
+    res.json(users.map((user) => user.toJSON()));
+  } catch (error) {
+    console.error('listUsers error', error);
+    res.status(500).json({ message: 'No se pudo obtener la lista de usuarios.' });
+  }
+};
+
+exports.createUser = async (req, res) => {
+  try {
+    const { name, email, password, role, adAccount } = req.body;
+
+    const trimmedName = typeof name === 'string' ? name.trim() : '';
+    const trimmedEmail = typeof email === 'string' ? email.trim().toLowerCase() : '';
+
+    if (!trimmedName || !trimmedEmail || !password) {
+      return res
+        .status(400)
+        .json({ message: 'Nombre, correo y contraseña son obligatorios.' });
+    }
+
+    const existingUser = await User.findOne({ email: trimmedEmail });
+    if (existingUser) {
+      return res.status(409).json({ message: 'El correo ya está registrado.' });
+    }
+
+    const passwordHash = hashPassword(password);
+    const resolvedRole = resolveRole(role);
+
+    const user = await User.create({
+      name: trimmedName,
+      email: trimmedEmail,
+      passwordHash,
+      role: resolvedRole,
+      adAccount: formatAdAccount(adAccount),
+    });
+
+    res.status(201).json({ user: user.toJSON() });
+  } catch (error) {
+    console.error('createUser error', error);
+    res.status(500).json({ message: 'No se pudo crear la cuenta.' });
+  }
+};
+
+exports.updateUser = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { role, adAccount, password } = req.body;
+
+    const user = await User.findById(id);
+    if (!user) {
+      return res.status(404).json({ message: 'Usuario no encontrado.' });
+    }
+
+    if (role !== undefined) {
+      const nextRole = resolveRole(role);
+      if (user.role === 'ADMIN' && nextRole !== 'ADMIN') {
+        const adminCount = await User.countDocuments({ role: 'ADMIN' });
+        if (adminCount <= 1) {
+          return res
+            .status(400)
+            .json({ message: 'Debe existir al menos un administrador activo.' });
+        }
+      }
+      user.role = nextRole;
+    }
+
+    if (adAccount !== undefined) {
+      user.adAccount = formatAdAccount(adAccount);
+    }
+
+    if (password) {
+      user.passwordHash = hashPassword(password);
+    }
+
+    await user.save();
+
+    res.json({ user: user.toJSON() });
+  } catch (error) {
+    console.error('updateUser error', error);
+    res
+      .status(500)
+      .json({ message: 'No se pudieron actualizar los datos del usuario.' });
+  }
+};

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const userController = require('../controllers/userController');
+const { authenticate, authorizeRoles } = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(authenticate, authorizeRoles('ADMIN'));
+
+router.get('/', userController.listUsers);
+router.post('/', userController.createUser);
+router.patch('/:id', userController.updateUser);
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import DispatchGuidesPage from './pages/DispatchGuidesPage';
 import ProductDecommissionPage from './pages/ProductDecommissionPage';
 import StockConsultPage from './pages/StockConsultPage';
 import ProductCatalogPage from './pages/ProductCatalogPage';
+import AccountManagementPage from './pages/AccountManagementPage';
 
 function App() {
   const { isAuthenticated } = useAuth();
@@ -35,6 +36,7 @@ function App() {
         <Route path="productos/catalogo" element={<ProductCatalogPage />} />
         <Route path="guias" element={<DispatchGuidesPage />} />
         <Route path="bajas" element={<ProductDecommissionPage />} />
+        <Route path="administracion/cuentas" element={<AccountManagementPage />} />
       </Route>
       <Route
         path="*"

--- a/frontend/src/components/DispatchGuideManager.jsx
+++ b/frontend/src/components/DispatchGuideManager.jsx
@@ -6,7 +6,15 @@ const initialState = {
   dispatchDate: '',
 };
 
-function DispatchGuideManager({ guides, onUpload, onRefresh, onDownload, onDelete, isUploading }) {
+function DispatchGuideManager({
+  guides,
+  onUpload,
+  onRefresh,
+  onDownload,
+  onDelete,
+  isUploading,
+  isFiltered = false,
+}) {
   const [values, setValues] = useState(initialState);
   const [error, setError] = useState('');
   const fileInputRef = useRef(null);
@@ -100,7 +108,9 @@ function DispatchGuideManager({ guides, onUpload, onRefresh, onDownload, onDelet
             {guides.length === 0 && (
               <tr>
                 <td colSpan={5} className="muted">
-                  No hay guías cargadas.
+                  {isFiltered
+                    ? 'No hay guías que coincidan con la búsqueda.'
+                    : 'No hay guías cargadas.'}
                 </td>
               </tr>
             )}
@@ -138,6 +148,7 @@ DispatchGuideManager.defaultProps = {
   onDownload: () => {},
   onDelete: () => {},
   isUploading: false,
+  isFiltered: false,
 };
 
 export default DispatchGuideManager;

--- a/frontend/src/components/ProductTable.jsx
+++ b/frontend/src/components/ProductTable.jsx
@@ -10,7 +10,7 @@ function formatType(type) {
   return type;
 }
 
-function ProductTable({ products, onSelect, selectedProductId }) {
+function ProductTable({ products, onSelect, selectedProductId, isFiltered = false }) {
   return (
     <div className="card">
       <div className="card-header">
@@ -34,8 +34,10 @@ function ProductTable({ products, onSelect, selectedProductId }) {
           <tbody>
             {products.length === 0 && (
               <tr>
-                <td colSpan={7} className="muted">
-                  Aún no hay productos registrados.
+                <td colSpan={8} className="muted">
+                  {isFiltered
+                    ? 'No hay productos que coincidan con la búsqueda.'
+                    : 'Aún no hay productos registrados.'}
                 </td>
               </tr>
             )}

--- a/frontend/src/pages/AccountManagementPage.jsx
+++ b/frontend/src/pages/AccountManagementPage.jsx
@@ -1,0 +1,376 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { filterUsers, normalizeSearchTerm } from '../utils/search';
+
+const ROLE_OPTIONS = [
+  { value: 'ADMIN', label: 'Administrador' },
+  { value: 'MANAGER', label: 'Encargado' },
+  { value: 'VIEWER', label: 'Consulta' },
+];
+
+const INITIAL_FORM_STATE = {
+  name: '',
+  email: '',
+  password: '',
+  role: 'VIEWER',
+  adAccount: '',
+};
+
+function AccountManagementPage() {
+  const { request, hasRole, user: currentUser } = useAuth();
+  const isAdmin = hasRole('ADMIN');
+
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const [formValues, setFormValues] = useState(INITIAL_FORM_STATE);
+  const [formError, setFormError] = useState('');
+  const [formSuccess, setFormSuccess] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const [draftChanges, setDraftChanges] = useState({});
+  const [savingUserId, setSavingUserId] = useState(null);
+  const [updateMessage, setUpdateMessage] = useState('');
+  const [updateError, setUpdateError] = useState('');
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    setUpdateMessage('');
+    setUpdateError('');
+    try {
+      const data = await request('/users');
+      setUsers(data);
+    } catch (err) {
+      setError(err.message || 'No se pudo obtener la lista de usuarios.');
+      setUsers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    if (isAdmin) {
+      loadUsers();
+    }
+  }, [isAdmin, loadUsers]);
+
+  const handleFormChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((prev) => ({ ...prev, [name]: value }));
+    setFormError('');
+    setFormSuccess('');
+  };
+
+  const handleCreateUser = async (event) => {
+    event.preventDefault();
+    setFormError('');
+    setFormSuccess('');
+    setUpdateMessage('');
+    setUpdateError('');
+
+    const trimmedName = formValues.name.trim();
+    const trimmedEmail = formValues.email.trim();
+    const trimmedPassword = formValues.password.trim();
+
+    if (!trimmedName || !trimmedEmail || !trimmedPassword) {
+      setFormError('Completa el nombre, correo y contraseña.');
+      return;
+    }
+
+    setCreating(true);
+    try {
+      await request('/users', {
+        method: 'POST',
+        data: {
+          name: trimmedName,
+          email: trimmedEmail,
+          password: trimmedPassword,
+          role: formValues.role,
+          adAccount: formValues.adAccount.trim(),
+        },
+      });
+      setFormValues(INITIAL_FORM_STATE);
+      setFormSuccess('Cuenta creada correctamente.');
+      await loadUsers();
+    } catch (err) {
+      setFormError(err.message || 'No se pudo crear la cuenta.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDraftChange = (userId, field, value) => {
+    setDraftChanges((prev) => ({
+      ...prev,
+      [userId]: {
+        ...prev[userId],
+        [field]: value,
+      },
+    }));
+    setUpdateMessage('');
+    setUpdateError('');
+  };
+
+  const handleSaveUser = async (user) => {
+    const draft = draftChanges[user._id] || {};
+    const roleValue = draft.role ?? user.role;
+    const adAccountValue = draft.adAccount ?? (user.adAccount || '');
+
+    const trimmedAdAccount = adAccountValue.trim();
+    const originalAdAccount = (user.adAccount || '').trim();
+
+    const payload = {};
+    if (roleValue !== user.role) {
+      payload.role = roleValue;
+    }
+    if (trimmedAdAccount !== originalAdAccount) {
+      payload.adAccount = trimmedAdAccount;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      return;
+    }
+
+    setSavingUserId(user._id);
+    setUpdateError('');
+    setUpdateMessage('');
+
+    try {
+      const response = await request(`/users/${user._id}`, {
+        method: 'PATCH',
+        data: payload,
+      });
+      setUsers((prev) =>
+        prev.map((item) => (item._id === user._id ? response.user : item))
+      );
+      setDraftChanges((prev) => {
+        const next = { ...prev };
+        delete next[user._id];
+        return next;
+      });
+      setUpdateMessage('Cambios guardados correctamente.');
+    } catch (err) {
+      setUpdateError(err.message || 'No se pudo actualizar la cuenta.');
+    } finally {
+      setSavingUserId(null);
+    }
+  };
+
+  const filteredUsers = useMemo(
+    () => filterUsers(users, searchTerm),
+    [users, searchTerm]
+  );
+  const normalizedSearch = useMemo(() => normalizeSearchTerm(searchTerm), [searchTerm]);
+
+  const handleSearchChange = (event) => {
+    setSearchTerm(event.target.value);
+  };
+
+  if (!isAdmin) {
+    return (
+      <section className="dashboard-section">
+        <div className="card">
+          <h2>Administración de cuentas</h2>
+          <p className="muted">Solo los administradores pueden gestionar cuentas de acceso.</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Administración de cuentas</h2>
+          <p className="muted">Crea nuevas cuentas y administra los roles disponibles en el sistema.</p>
+        </div>
+        <div className="section-actions">
+          <label className="inline-filter">
+            Buscar
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={handleSearchChange}
+              placeholder="Nombre, correo, rol..."
+            />
+          </label>
+          <button type="button" className="secondary" onClick={loadUsers} disabled={loading}>
+            {loading ? 'Actualizando...' : 'Actualizar'}
+          </button>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-header">
+          <h3>Crear nueva cuenta</h3>
+          <p className="muted">Registra usuarios adicionales y define su rol inicial.</p>
+        </div>
+        <form className="form-grid" onSubmit={handleCreateUser}>
+          <label>
+            Nombre
+            <input
+              name="name"
+              value={formValues.name}
+              onChange={handleFormChange}
+              placeholder="Nombre y apellido"
+              required
+            />
+          </label>
+          <label>
+            Correo electrónico
+            <input
+              type="email"
+              name="email"
+              value={formValues.email}
+              onChange={handleFormChange}
+              placeholder="usuario@organizacion.cl"
+              required
+            />
+          </label>
+          <label>
+            Contraseña temporal
+            <input
+              type="password"
+              name="password"
+              value={formValues.password}
+              onChange={handleFormChange}
+              placeholder="Define una contraseña provisoria"
+              required
+            />
+          </label>
+          <label>
+            Rol
+            <select name="role" value={formValues.role} onChange={handleFormChange}>
+              {ROLE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Cuenta de directorio activo (opcional)
+            <input
+              name="adAccount"
+              value={formValues.adAccount}
+              onChange={handleFormChange}
+              placeholder="usuario.ad"
+            />
+          </label>
+          {formError && <p className="error">{formError}</p>}
+          {formSuccess && <p className="success-text">{formSuccess}</p>}
+          <div className="actions">
+            <button type="submit" className="primary" disabled={creating}>
+              {creating ? 'Creando...' : 'Crear cuenta'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div className="card">
+        <div className="card-header">
+          <h3>Cuentas registradas</h3>
+          <p className="muted">Actualiza roles, cuentas de directorio y revisa la última modificación.</p>
+        </div>
+        {error && <p className="error">{error}</p>}
+        {updateError && <p className="error">{updateError}</p>}
+        {updateMessage && <p className="success-text">{updateMessage}</p>}
+        <div className="table-responsive">
+          <table className="data-table compact">
+            <thead>
+              <tr>
+                <th>Nombre</th>
+                <th>Correo</th>
+                <th>Rol</th>
+                <th>Cuenta AD</th>
+                <th>Actualizado</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <tr>
+                  <td colSpan={6} className="muted">
+                    Cargando cuentas...
+                  </td>
+                </tr>
+              )}
+              {!loading && filteredUsers.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="muted">
+                    {normalizedSearch
+                      ? 'No hay cuentas que coincidan con la búsqueda.'
+                      : 'Aún no hay usuarios registrados.'}
+                  </td>
+                </tr>
+              )}
+              {filteredUsers.map((user) => {
+                const draft = draftChanges[user._id] || {};
+                const roleValue = draft.role ?? user.role;
+                const adAccountValue = draft.adAccount ?? (user.adAccount || '');
+                const trimmedOriginalAd = (user.adAccount || '').trim();
+                const trimmedDraftAd = adAccountValue.trim();
+                const hasChanges =
+                  roleValue !== user.role || trimmedDraftAd !== trimmedOriginalAd;
+                const isSaving = savingUserId === user._id;
+                const isCurrentUser = currentUser?._id === user._id;
+                const updatedLabel = user.updatedAt
+                  ? new Date(user.updatedAt).toLocaleDateString('es-CL')
+                  : '—';
+
+                return (
+                  <tr key={user._id}>
+                    <td>
+                      <strong>{user.name}</strong>
+                      {isCurrentUser && <div className="muted small-text">Tu cuenta actual</div>}
+                    </td>
+                    <td>{user.email}</td>
+                    <td>
+                      <select
+                        value={roleValue}
+                        onChange={(event) =>
+                          handleDraftChange(user._id, 'role', event.target.value)
+                        }
+                      >
+                        {ROLE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td>
+                      <input
+                        value={adAccountValue}
+                        onChange={(event) =>
+                          handleDraftChange(user._id, 'adAccount', event.target.value)
+                        }
+                        placeholder="Sin cuenta"
+                      />
+                    </td>
+                    <td>{updatedLabel}</td>
+                    <td>
+                      <button
+                        type="button"
+                        className="secondary compact"
+                        onClick={() => handleSaveUser(user)}
+                        disabled={!hasChanges || isSaving}
+                      >
+                        {isSaving ? 'Guardando...' : 'Guardar cambios'}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default AccountManagementPage;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -11,15 +11,26 @@ const NAV_ITEMS = [
   { to: 'productos/catalogo', label: 'Catálogo de productos', requiresManage: true },
   { to: 'guias', label: 'Guías de despacho', requiresManage: true },
   { to: 'bajas', label: 'Bajas de inventario', requiresManage: true },
+  { to: 'administracion/cuentas', label: 'Administrar cuentas', requiresAdmin: true },
 ];
 
 function Dashboard() {
   const { user, logout, hasRole } = useAuth();
   const canManage = hasRole('ADMIN', 'MANAGER');
+  const isAdmin = hasRole('ADMIN');
 
   const navItems = useMemo(
-    () => NAV_ITEMS.filter((item) => !item.requiresManage || canManage),
-    [canManage]
+    () =>
+      NAV_ITEMS.filter((item) => {
+        if (item.requiresAdmin) {
+          return isAdmin;
+        }
+        if (item.requiresManage) {
+          return canManage;
+        }
+        return true;
+      }),
+    [canManage, isAdmin]
   );
 
   return (

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -68,6 +68,11 @@ small,
   font-weight: 400;
 }
 
+.success-text {
+  color: #107a3b;
+  font-weight: 600;
+}
+
 .small-text {
   font-size: 0.85rem;
 }

--- a/frontend/src/utils/search.js
+++ b/frontend/src/utils/search.js
@@ -1,0 +1,174 @@
+import { getProductStatusLabel } from './productStatus';
+
+const PRODUCT_TYPE_LABELS = {
+  PURCHASED: 'Compra',
+  RENTAL: 'Arriendo',
+};
+
+export function normalizeSearchTerm(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim().toLowerCase();
+}
+
+export function matchesSearchTerm(value, term) {
+  if (!term) {
+    return true;
+  }
+
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  return String(value).toLowerCase().includes(term);
+}
+
+export function matchesAnyField(fields, term) {
+  if (!term) {
+    return true;
+  }
+
+  return fields.some((field) => matchesSearchTerm(field, term));
+}
+
+function toLocaleDate(value, { includeTime = false } = {}) {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return includeTime ? date.toLocaleString('es-CL') : date.toLocaleDateString('es-CL');
+}
+
+function getProductSearchFields(product) {
+  if (!product) {
+    return [];
+  }
+
+  const typeLabel = PRODUCT_TYPE_LABELS[product.type] || product.type;
+  const statusLabel = getProductStatusLabel(product.status);
+
+  return [
+    product.productModel?.name,
+    product.name,
+    product.productModel?.partNumber,
+    product.partNumber,
+    product.serialNumber,
+    product.productModel?.description,
+    product.description,
+    product.inventoryNumber,
+    product.rentalId,
+    product.dispatchGuide?.guideNumber,
+    product.dispatchGuide?.vendor,
+    product.currentAssignment?.assignedTo,
+    product.currentAssignment?.location,
+    product.decommissionReason,
+    product.decommissionedBy?.name,
+    product.status,
+    statusLabel,
+    product.type,
+    typeLabel,
+    toLocaleDate(product.createdAt),
+    toLocaleDate(product.updatedAt),
+    toLocaleDate(product.decommissionedAt, { includeTime: true }),
+  ];
+}
+
+export function filterProductsBySearch(products, term, options = {}) {
+  const normalizedTerm = normalizeSearchTerm(term);
+  const statusFilter = options.status ?? null;
+  const list = Array.isArray(products) ? products : [];
+
+  let filtered = list;
+  if (statusFilter && statusFilter !== 'ALL') {
+    filtered = filtered.filter((item) => item.status === statusFilter);
+  }
+
+  if (!normalizedTerm) {
+    return filtered;
+  }
+
+  return filtered.filter((product) =>
+    matchesAnyField(getProductSearchFields(product), normalizedTerm)
+  );
+}
+
+export function filterDispatchGuides(guides, term) {
+  const normalizedTerm = normalizeSearchTerm(term);
+  const list = Array.isArray(guides) ? guides : [];
+
+  if (!normalizedTerm) {
+    return list;
+  }
+
+  return list.filter((guide) =>
+    matchesAnyField(
+      [
+        guide.guideNumber,
+        guide.vendor,
+        guide.fileName,
+        guide.createdBy?.name,
+        guide.createdBy?.email,
+        guide.dispatchDate,
+        toLocaleDate(guide.dispatchDate),
+      ],
+      normalizedTerm
+    )
+  );
+}
+
+export function filterStockSummary(summary, term) {
+  const normalizedTerm = normalizeSearchTerm(term);
+  const list = Array.isArray(summary) ? summary : [];
+
+  if (!normalizedTerm) {
+    return list;
+  }
+
+  return list.filter((item) =>
+    matchesAnyField(
+      [
+        item.name,
+        item.partNumber,
+        item.description,
+        item.productModelId,
+        item.productModelId ? String(item.productModelId) : null,
+        item.totals?.total,
+        item.totals?.available,
+        item.totals?.assigned,
+        item.totals?.decommissioned,
+        item.typeBreakdown?.purchased,
+        item.typeBreakdown?.rental,
+      ],
+      normalizedTerm
+    )
+  );
+}
+
+export function filterUsers(users, term) {
+  const normalizedTerm = normalizeSearchTerm(term);
+  const list = Array.isArray(users) ? users : [];
+
+  if (!normalizedTerm) {
+    return list;
+  }
+
+  return list.filter((user) =>
+    matchesAnyField(
+      [
+        user.name,
+        user.email,
+        user.role,
+        user.adAccount,
+        toLocaleDate(user.createdAt, { includeTime: true }),
+        toLocaleDate(user.updatedAt, { includeTime: true }),
+      ],
+      normalizedTerm
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- add admin-only user management endpoints and front-end module to create accounts and adjust roles
- introduce shared search utilities and hook up search inputs across guides, inventory, stock consult and decommission pages
- refresh shared table messaging and styles to reflect filtered states and provide user feedback

## Testing
- npm --prefix frontend run build
- npm --prefix backend run test

------
https://chatgpt.com/codex/tasks/task_b_68d364f30d8c8321817f7b1f90c43499