### PR TITLE
Enable deletions and improve product model selection

### DIFF
--- a/backend/src/controllers/productModelController.js
+++ b/backend/src/controllers/productModelController.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const ProductModel = require('../models/ProductModel');
+const Product = require('../models/Product');
 
 exports.createProductModel = async (req, res) => {
   try {
@@ -41,5 +42,35 @@ exports.listProductModels = async (req, res) => {
   } catch (error) {
     console.error('listProductModels error', error);
     res.status(500).json({ message: 'No se pudieron obtener los modelos de producto.' });
+  }
+};
+
+exports.deleteProductModel = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: 'Identificador de modelo inválido.' });
+    }
+
+    const productModel = await ProductModel.findById(id);
+    if (!productModel) {
+      return res.status(404).json({ message: 'Modelo de producto no encontrado.' });
+    }
+
+    const relatedProducts = await Product.countDocuments({ productModel: id });
+    if (relatedProducts > 0) {
+      return res.status(400).json({
+        message:
+          'No se puede eliminar el modelo porque existen productos registrados que lo utilizan.',
+      });
+    }
+
+    await productModel.deleteOne();
+
+    res.json({ message: 'Modelo eliminado correctamente.' });
+  } catch (error) {
+    console.error('deleteProductModel error', error);
+    res.status(500).json({ message: 'No se pudo eliminar el modelo de producto.' });
   }
 };

--- a/backend/src/routes/productModelRoutes.js
+++ b/backend/src/routes/productModelRoutes.js
@@ -13,4 +13,11 @@ router.post(
   productModelController.createProductModel
 );
 
+router.delete(
+  '/:id',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  productModelController.deleteProductModel
+);
+
 module.exports = router;

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -9,5 +9,6 @@ router.use(authenticate, authorizeRoles('ADMIN'));
 router.get('/', userController.listUsers);
 router.post('/', userController.createUser);
 router.patch('/:id', userController.updateUser);
+router.delete('/:id', userController.deleteUser);
 
 module.exports = router;

--- a/frontend/src/pages/StockConsultPage.jsx
+++ b/frontend/src/pages/StockConsultPage.jsx
@@ -32,23 +32,6 @@ function StockConsultPage() {
     [summary, searchTerm]
   );
 
-  const totals = useMemo(() => {
-    if (!filteredSummary.length) {
-      return null;
-    }
-    return filteredSummary.reduce(
-      (acc, item) => ({
-        total: acc.total + item.totals.total,
-        available: acc.available + item.totals.available,
-        assigned: acc.assigned + item.totals.assigned,
-        decommissioned: acc.decommissioned + item.totals.decommissioned,
-        purchased: acc.purchased + item.typeBreakdown.purchased,
-        rental: acc.rental + item.typeBreakdown.rental,
-      }),
-      { total: 0, available: 0, assigned: 0, decommissioned: 0, purchased: 0, rental: 0 }
-    );
-  }, [filteredSummary]);
-
   const normalizedSearch = useMemo(() => normalizeSearchTerm(searchTerm), [searchTerm]);
 
   const handleSearchChange = (event) => {
@@ -139,17 +122,6 @@ function StockConsultPage() {
                   <td>{item.typeBreakdown.rental}</td>
                 </tr>
               ))}
-              {totals && filteredSummary.length > 0 && (
-                <tr>
-                  <td colSpan={2}>Totales generales</td>
-                  <td>{totals.total}</td>
-                  <td>{totals.available}</td>
-                  <td>{totals.assigned}</td>
-                  <td>{totals.decommissioned}</td>
-                  <td>{totals.purchased}</td>
-                  <td>{totals.rental}</td>
-                </tr>
-              )}
             </tbody>
           </table>
         </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -556,6 +556,12 @@ button.danger {
   padding: 0.6rem 0.75rem;
 }
 
+.table-action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .status {
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
@@ -597,6 +603,11 @@ button.danger {
 .form-grid .actions {
   display: flex;
   gap: 0.75rem;
+}
+
+.select-search-group {
+  display: grid;
+  gap: 0.5rem;
 }
 
 .form-grid .full-width {


### PR DESCRIPTION
## Summary
- allow deleting product models only when they have no associated inventory and expose the API endpoint
- let administrators remove user accounts while preserving at least one active admin
- add model search to the product entry form, expose delete controls in the catalog and account pages, and remove the global total row from the stock summary

## Testing
- npm --prefix frontend run build
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_b_68d36a2a87f48321b51f542daac83eb6