### PR TITLE
Add success popups with auto reload for inventory flows

### DIFF
--- a/frontend/src/pages/AssignmentsPage.jsx
+++ b/frontend/src/pages/AssignmentsPage.jsx
@@ -148,6 +148,8 @@ function AssignmentsPage() {
         } else {
           await loadAssignmentHistory(updatedProduct?._id || targetId);
         }
+        window.alert('Producto asignado correctamente.');
+        window.location.reload();
       } finally {
         setAssignmentProcessing(false);
       }
@@ -208,6 +210,8 @@ function AssignmentsPage() {
         } else {
           await loadAssignmentHistory(updatedProduct?._id || targetId);
         }
+        window.alert('Producto liberado correctamente.');
+        window.location.reload();
       } finally {
         setAssignmentProcessing(false);
       }

--- a/frontend/src/pages/DispatchGuidesPage.jsx
+++ b/frontend/src/pages/DispatchGuidesPage.jsx
@@ -44,6 +44,8 @@ function DispatchGuidesPage() {
           formData,
         });
         await loadGuides();
+        window.alert('Guía de despacho ingresada correctamente.');
+        window.location.reload();
       } finally {
         setUploadingGuide(false);
       }

--- a/frontend/src/pages/ProductCatalogPage.jsx
+++ b/frontend/src/pages/ProductCatalogPage.jsx
@@ -100,6 +100,8 @@ function ProductCatalogPage() {
       });
       setFormValues(initialFormState);
       await loadModels();
+      window.alert('Categoría creada correctamente.');
+      window.location.reload();
     } catch (err) {
       setFormError(err.message || 'No se pudo registrar el modelo.');
     } finally {

--- a/frontend/src/pages/ProductEntryPage.jsx
+++ b/frontend/src/pages/ProductEntryPage.jsx
@@ -12,7 +12,6 @@ function ProductEntryPage() {
   const [loadingModels, setLoadingModels] = useState(false);
   const [modelsError, setModelsError] = useState('');
   const [creatingProduct, setCreatingProduct] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
 
   const canManage = hasRole('ADMIN', 'MANAGER');
 
@@ -54,15 +53,14 @@ function ProductEntryPage() {
   const handleCreateProduct = useCallback(
     async (payload) => {
       setCreatingProduct(true);
-      setSuccessMessage('');
       try {
         await request('/products', {
           method: 'POST',
           data: payload,
         });
-        setSuccessMessage('Producto registrado correctamente.');
+        window.alert('Producto registrado correctamente.');
+        window.location.reload();
       } catch (error) {
-        setSuccessMessage('');
         throw error;
       } finally {
         setCreatingProduct(false);
@@ -122,12 +120,6 @@ function ProductEntryPage() {
       {modelsError && (
         <div className="card">
           <strong>Error:</strong> {modelsError}
-        </div>
-      )}
-
-      {successMessage && (
-        <div className="card success-card">
-          <strong>Éxito:</strong> {successMessage}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- show browser alerts and force reload after creating product models, products, and dispatch guides
- trigger success popups after assigning or liberating products to keep state consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d43d352c5083218806789f56262c7c