### PR TITLE
Improve server startup resilience

### DIFF
--- a/backend/src/seed.js
+++ b/backend/src/seed.js
@@ -16,7 +16,7 @@ const role = 'ADMIN';
 
 const MONGODB_URI =
   process.env.MONGODB_URI ||
-  'mongodb+srv://ERPCHA>:ERPCHA@basededatos1.hwq53bl.mongodb.net/?retryWrites=true&w=majority&appName=Basededatos1';
+  'mongodb+srv://ERPCHA:ERPCHA@basededatos1.hwq53bl.mongodb.net/?retryWrites=true&w=majority&appName=Basededatos1';
 
 async function main() {
   try {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,10 +4,32 @@ const app = require('./app');
 
 dotenv.config();
 
-const PORT = process.env.PORT || 4000;
+const DEFAULT_PORT = 4000;
+const MAX_PORT_RETRIES = 5;
+
+const PORT = parseInt(process.env.PORT || DEFAULT_PORT, 10);
 const MONGODB_URI =
   process.env.MONGODB_URI ||
-  'mongodb+srv://ERPCHA>:ERPCHA@basededatos1.hwq53bl.mongodb.net/?retryWrites=true&w=majority&appName=Basededatos1';
+  'mongodb+srv://ERPCHA:ERPCHA@basededatos1.hwq53bl.mongodb.net/?retryWrites=true&w=majority&appName=Basededatos1';
+
+async function listenWithRetry(app, port, attempt = 0) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(port, () => resolve(server));
+
+    server.on('error', (error) => {
+      if (error.code === 'EADDRINUSE' && attempt < MAX_PORT_RETRIES) {
+        const nextPort = port + 1;
+        console.warn(
+          `Port ${port} is already in use. Retrying with port ${nextPort} (${attempt + 1}/${MAX_PORT_RETRIES}).`
+        );
+        resolve(listenWithRetry(app, nextPort, attempt + 1));
+        return;
+      }
+
+      reject(error);
+    });
+  });
+}
 
 async function start() {
   try {
@@ -17,9 +39,10 @@ async function start() {
     });
     console.log('MongoDB connection established');
 
-    app.listen(PORT, () => {
-      console.log(`Server running on port ${PORT}`);
-    });
+    const server = await listenWithRetry(app, PORT);
+    const addressInfo = server.address();
+    const activePort = typeof addressInfo === 'string' ? PORT : addressInfo.port;
+    console.log(`Server running on port ${activePort}`);
   } catch (error) {
     console.error('Failed to start server', error);
     process.exit(1);


### PR DESCRIPTION
## Summary
- add a retrying listener helper so the API server automatically selects the next available port when the default port is already taken
- ensure the active port is reported in the startup log message and keep the process failure inside the guarded section
- fix the default MongoDB connection string fallback used by the server and seeding script

## Testing
- npm run dev *(fails: remote MongoDB URI cannot be resolved in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4403b06808321b161adb7c11e0a2e