### PR TITLE
Forzar recarga automática tras asignar o liberar

### DIFF
--- a/frontend/src/pages/AssignmentsPage.jsx
+++ b/frontend/src/pages/AssignmentsPage.jsx
@@ -149,9 +149,9 @@ function AssignmentsPage() {
           await loadAssignmentHistory(updatedProduct?._id || targetId);
         }
         window.alert('Producto asignado correctamente.');
-        window.location.reload();
       } finally {
         setAssignmentProcessing(false);
+        window.location.reload();
       }
     },
     [
@@ -211,9 +211,9 @@ function AssignmentsPage() {
           await loadAssignmentHistory(updatedProduct?._id || targetId);
         }
         window.alert('Producto liberado correctamente.');
-        window.location.reload();
       } finally {
         setAssignmentProcessing(false);
+        window.location.reload();
       }
     },
     [


### PR DESCRIPTION
## Summary
- mover la recarga de la página al bloque `finally` de las acciones de asignar y liberar
- garantizar que la interfaz se refresque automáticamente incluso si ocurre un error en la solicitud

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d44246110083218fa71872baf9d42f