### PR TITLE
Fix assignment history persistence and refresh

### DIFF
--- a/backend/src/controllers/productController.js
+++ b/backend/src/controllers/productController.js
@@ -249,6 +249,8 @@ exports.assignProduct = async (req, res) => {
       notes,
     });
 
+    await assignment.populate('performedBy', 'name email role');
+
     product.currentAssignment = {
       assignedTo,
       location,
@@ -303,6 +305,8 @@ exports.unassignProduct = async (req, res) => {
       performedBy: req.user._id,
       notes,
     });
+
+    await assignment.populate('performedBy', 'name email role');
 
     product.currentAssignment = undefined;
     product.status = 'AVAILABLE';

--- a/frontend/src/pages/AssignmentsPage.jsx
+++ b/frontend/src/pages/AssignmentsPage.jsx
@@ -51,7 +51,7 @@ function AssignmentsPage() {
         const history = await request(`/products/${productId}/assignments`);
         setAssignmentHistory(Array.isArray(history) ? history : []);
       } catch (error) {
-        setAssignmentHistory([]);
+        console.error('No se pudo cargar el historial de asignaciones.', error);
       } finally {
         setHistoryLoading(false);
       }
@@ -114,6 +114,7 @@ function AssignmentsPage() {
           data: payload,
         });
         const updatedProduct = response?.product;
+        const newAssignment = response?.assignment;
 
         if (updatedProduct?._id) {
           setProducts((current) => {
@@ -125,9 +126,20 @@ function AssignmentsPage() {
           });
           setSelectedProductId(updatedProduct._id);
         } else {
-          await loadProducts();
+          setSelectedProductId(targetId);
         }
 
+        if (newAssignment?._id) {
+          setAssignmentHistory((current) => {
+            const exists = current.some((item) => item._id === newAssignment._id);
+            if (exists) {
+              return current.map((item) => (item._id === newAssignment._id ? newAssignment : item));
+            }
+            return [newAssignment, ...current];
+          });
+        }
+
+        await loadProducts();
         await loadAssignmentHistory(updatedProduct?._id || targetId);
         window.alert('Producto asignado correctamente.');
       } finally {
@@ -150,6 +162,7 @@ function AssignmentsPage() {
           data: payload,
         });
         const updatedProduct = response?.product;
+        const newAssignment = response?.assignment;
 
         if (updatedProduct?._id) {
           setProducts((current) => {
@@ -161,9 +174,20 @@ function AssignmentsPage() {
           });
           setSelectedProductId(updatedProduct._id);
         } else {
-          await loadProducts();
+          setSelectedProductId(targetId);
         }
 
+        if (newAssignment?._id) {
+          setAssignmentHistory((current) => {
+            const exists = current.some((item) => item._id === newAssignment._id);
+            if (exists) {
+              return current.map((item) => (item._id === newAssignment._id ? newAssignment : item));
+            }
+            return [newAssignment, ...current];
+          });
+        }
+
+        await loadProducts();
         await loadAssignmentHistory(updatedProduct?._id || targetId);
         window.alert('Producto liberado correctamente.');
       } finally {


### PR DESCRIPTION
## Summary
- populate assignment records with the usuario que ejecuta la acción al crear o liberar productos para que el historial registre al responsable
- actualizar la página de asignaciones para refrescar el listado y el historial tras asignar o liberar, mostrando inmediatamente el último movimiento y manteniendo el foco en el producto seleccionado
- registrar en consola los fallos al intentar recuperar el historial sin borrar los movimientos existentes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d4477bce688321ad26fc1dbdb71c77