### PR TITLE
Add assigned email to assignment records

### DIFF
--- a/backend/src/models/Assignment.js
+++ b/backend/src/models/Assignment.js
@@ -7,6 +7,7 @@ const assignmentSchema = new Schema(
     product: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
     action: { type: String, enum: ['ASSIGN', 'UNASSIGN'], required: true },
     assignedTo: { type: String, required: true },
+    assignedEmail: { type: String, trim: true },
     location: { type: String, required: true },
     assignmentDate: { type: Date, required: true },
     performedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },

--- a/backend/src/models/Product.js
+++ b/backend/src/models/Product.js
@@ -5,6 +5,7 @@ const { Schema } = mongoose;
 const assignmentSnapshotSchema = new Schema(
   {
     assignedTo: String,
+    assignedEmail: String,
     location: String,
     assignmentDate: Date,
   },

--- a/frontend/src/components/AssignmentHistory.jsx
+++ b/frontend/src/components/AssignmentHistory.jsx
@@ -10,6 +10,7 @@ function AssignmentHistory({ history, loading }) {
             <tr>
               <th>Acción</th>
               <th>Usuario asignado</th>
+              <th>Correo electrónico</th>
               <th>Ubicación</th>
               <th>Fecha</th>
               <th>Registrado por</th>
@@ -19,14 +20,14 @@ function AssignmentHistory({ history, loading }) {
           <tbody>
             {loading && (
               <tr>
-                <td colSpan={6} className="muted">
+                <td colSpan={7} className="muted">
                   Cargando movimientos...
                 </td>
               </tr>
             )}
             {!loading && history.length === 0 && (
               <tr>
-                <td colSpan={6} className="muted">
+                <td colSpan={7} className="muted">
                   No hay movimientos registrados.
                 </td>
               </tr>
@@ -39,6 +40,7 @@ function AssignmentHistory({ history, loading }) {
                   </span>
                 </td>
                 <td>{item.assignedTo}</td>
+                <td>{item.assignedEmail || '—'}</td>
                 <td>{item.location}</td>
                 <td>{new Date(item.assignmentDate).toLocaleString('es-CL')}</td>
                 <td>{item.performedBy?.name || '—'}</td>

--- a/frontend/src/components/ProductAssignmentPanel.jsx
+++ b/frontend/src/components/ProductAssignmentPanel.jsx
@@ -3,6 +3,7 @@ import { getProductStatusBadge, getProductStatusLabel, isDecommissioned } from '
 
 const emptyState = {
   assignedTo: '',
+  assignedEmail: '',
   location: '',
   assignmentDate: '',
   notes: '',
@@ -58,7 +59,7 @@ function ProductAssignmentPanel({
       return;
     }
 
-    if (!values.assignedTo || !values.location) {
+    if (!values.assignedTo || !values.assignedEmail || !values.location) {
       setError('Completa los campos obligatorios.');
       return;
     }
@@ -66,6 +67,7 @@ function ProductAssignmentPanel({
     try {
       await onAssign({
         assignedTo: values.assignedTo,
+        assignedEmail: values.assignedEmail,
         location: values.location,
         assignmentDate: values.assignmentDate || undefined,
         notes: values.notes || undefined,
@@ -151,6 +153,9 @@ function ProductAssignmentPanel({
             <p>
               <strong>{currentAssignment.assignedTo}</strong>
             </p>
+            {currentAssignment.assignedEmail && (
+              <p className="muted small-text">{currentAssignment.assignedEmail}</p>
+            )}
             <p className="muted">
               Ubicación: {currentAssignment.location} ·{' '}
               {new Date(currentAssignment.assignmentDate).toLocaleString('es-CL')}
@@ -180,9 +185,9 @@ function ProductAssignmentPanel({
         ) : !isProductAvailableForAssignment ? (
           <p className="muted">Debes liberar el producto antes de asignarlo a otra persona.</p>
         ) : canManage ? (
-            <form className="form-grid" onSubmit={handleAssign}>
-              <label>
-                Usuario
+          <form className="form-grid" onSubmit={handleAssign}>
+            <label>
+              Usuario
               <input
                 name="assignedTo"
                 value={values.assignedTo}
@@ -190,9 +195,20 @@ function ProductAssignmentPanel({
                 placeholder="Nombre del colaborador"
                 required
               />
-              </label>
-              <label>
-                Ubicación
+            </label>
+            <label>
+              Correo electrónico
+              <input
+                type="email"
+                name="assignedEmail"
+                value={values.assignedEmail}
+                onChange={handleChange}
+                placeholder="correo@empresa.cl"
+                required
+              />
+            </label>
+            <label>
+              Ubicación
               <input
                 name="location"
                 value={values.location}

--- a/frontend/src/components/ProductTable.jsx
+++ b/frontend/src/components/ProductTable.jsx
@@ -71,10 +71,15 @@ function ProductTable({ products, onSelect, selectedProductId, isFiltered = fals
                   </td>
                   <td>
                     {product.status === 'ASSIGNED' && product.currentAssignment ? (
-                      <span>
-                        {product.currentAssignment.assignedTo}{' '}
-                        <span className="muted">({product.currentAssignment.location})</span>
-                      </span>
+                      <div>
+                        <div>{product.currentAssignment.assignedTo}</div>
+                        {product.currentAssignment.assignedEmail && (
+                          <div className="muted small-text">
+                            {product.currentAssignment.assignedEmail}
+                          </div>
+                        )}
+                        <div className="muted">({product.currentAssignment.location})</div>
+                      </div>
                     ) : product.status === 'DECOMMISSIONED' ? (
                       <span className="muted">No disponible</span>
                     ) : (

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -220,6 +220,11 @@ function InventoryPage() {
                   <p>
                     <strong>{selectedProduct.currentAssignment.assignedTo}</strong>
                   </p>
+                  {selectedProduct.currentAssignment.assignedEmail && (
+                    <p className="muted small-text">
+                      {selectedProduct.currentAssignment.assignedEmail}
+                    </p>
+                  )}
                   <p className="muted">
                     Ubicación: {selectedProduct.currentAssignment.location} ·{' '}
                     {new Date(

--- a/frontend/src/pages/ProductDecommissionPage.jsx
+++ b/frontend/src/pages/ProductDecommissionPage.jsx
@@ -193,8 +193,11 @@ function ProductDecommissionPage() {
               </div>
               {selectedProduct.status === 'ASSIGNED' && selectedProduct.currentAssignment && (
                 <div className="full-width muted small-text">
-                  Actualmente asignado a {selectedProduct.currentAssignment.assignedTo} en{' '}
-                  {selectedProduct.currentAssignment.location}.
+                  Actualmente asignado a {selectedProduct.currentAssignment.assignedTo}
+                  {selectedProduct.currentAssignment.assignedEmail
+                    ? ` (${selectedProduct.currentAssignment.assignedEmail})`
+                    : ''}{' '}
+                  en {selectedProduct.currentAssignment.location}.
                 </div>
               )}
               <label className="full-width">

--- a/frontend/src/utils/search.js
+++ b/frontend/src/utils/search.js
@@ -66,6 +66,7 @@ function getProductSearchFields(product) {
     product.dispatchGuide?.guideNumber,
     product.dispatchGuide?.vendor,
     product.currentAssignment?.assignedTo,
+    product.currentAssignment?.assignedEmail,
     product.currentAssignment?.location,
     product.decommissionReason,
     product.decommissionedBy?.name,


### PR DESCRIPTION
## Summary
- capture the assigned collaborator email in assignment creation, persisting it alongside product snapshots
- surface the email throughout the assignment management UI, including forms, tables, and history, and allow it to be searched

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4b52d65a4832186cc6c20a468fdb1