### PR TITLE
Configure Vite dev proxy for API

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,18 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const DEV_PROXY_TARGET = process.env.VITE_DEV_SERVER_PROXY_TARGET || 'http://localhost:4000';
+
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    proxy: {
+      '/api': {
+        target: DEV_PROXY_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add a development proxy in Vite so /api calls reach the backend
- allow overriding the proxy target through the VITE_DEV_SERVER_PROXY_TARGET env var

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d571c0ee6c83218dfdfebb1f10f084