### PR TITLE
Improve frontend API configuration defaults

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# URL base del API para el frontend.
+# En desarrollo apunta al backend local por defecto (http://localhost:4000/api),
+# pero puedes sobrescribirlo si el backend se ejecuta en otra máquina.
+VITE_API_URL=http://localhost:4000/api
+
+# Si necesitas que el proxy de Vite reenvíe las peticiones a otra URL durante el
+# desarrollo, descomenta la línea siguiente y ajusta la URL base sin el sufijo /api.
+# VITE_DEV_SERVER_PROXY_TARGET=http://localhost:4000

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,18 +1,23 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-const DEV_PROXY_TARGET = process.env.VITE_DEV_SERVER_PROXY_TARGET || 'http://localhost:4000';
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const proxyTarget = env.VITE_DEV_SERVER_PROXY_TARGET?.trim();
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: DEV_PROXY_TARGET,
-        changeOrigin: true,
-        secure: false,
-      },
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: proxyTarget
+        ? {
+            '/api': {
+              target: proxyTarget,
+              changeOrigin: true,
+              secure: false,
+            },
+          }
+        : undefined,
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary
- make the frontend API client default to the local backend in development and surface a clearer network error
- load environment variables in the Vite config and only enable the proxy when a target is defined
- add a frontend `.env.example` documenting API and proxy configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d573b91f988321a578a3b97284de59