### PR TITLE
Add PDF export for product assignment history

### DIFF
--- a/backend/src/routes/productRoutes.js
+++ b/backend/src/routes/productRoutes.js
@@ -42,6 +42,12 @@ router.get(
   productController.getAssignmentHistory
 );
 
+router.get(
+  '/:id/assignments/pdf',
+  authenticate,
+  productController.downloadAssignmentHistoryPdf
+);
+
 router.post(
   '/:id/decommission',
   authenticate,

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -41,7 +41,10 @@ async function parseResponse(response) {
   return response.text();
 }
 
-export async function apiRequest(path, { method = 'GET', token, data, formData } = {}) {
+export async function apiRequest(
+  path,
+  { method = 'GET', token, data, formData, responseType } = {}
+) {
   const headers = new Headers();
   let body;
 
@@ -87,6 +90,14 @@ export async function apiRequest(path, { method = 'GET', token, data, formData }
 
   if (response.status === 204) {
     return null;
+  }
+
+  if (responseType === 'blob') {
+    return response.blob();
+  }
+
+  if (responseType === 'text') {
+    return response.text();
   }
 
   return parseResponse(response);

--- a/frontend/src/components/AssignmentHistory.jsx
+++ b/frontend/src/components/AssignmentHistory.jsx
@@ -1,8 +1,16 @@
-function AssignmentHistory({ history, loading }) {
+function AssignmentHistory({ history, loading, onDownload, product }) {
   return (
     <div className="card">
       <div className="card-header">
         <h3>Historial de asignaciones</h3>
+        <button
+          type="button"
+          className="secondary"
+          onClick={onDownload}
+          disabled={!onDownload || !product || loading}
+        >
+          Descargar PDF
+        </button>
       </div>
       <div className="table-responsive">
         <table className="data-table compact">
@@ -57,6 +65,8 @@ function AssignmentHistory({ history, loading }) {
 AssignmentHistory.defaultProps = {
   history: [],
   loading: false,
+  onDownload: undefined,
+  product: null,
 };
 
 export default AssignmentHistory;


### PR DESCRIPTION
## Summary
- implement backend PDF generation for product assignment history downloads and expose a dedicated route
- update the frontend assignment history table with a download action and support binary API responses
- add client-side handling to trigger the PDF download using the authenticated API client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5ad2e0cc48321abc514921819d410