### PR TITLE
Add product editing workflow to inventory page

### DIFF
--- a/frontend/src/components/ProductEditForm.jsx
+++ b/frontend/src/components/ProductEditForm.jsx
@@ -1,0 +1,301 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function buildInitialState(product) {
+  if (!product) {
+    return {
+      productModelId: '',
+      serialNumber: '',
+      inventoryNumber: '',
+      rentalId: '',
+      dispatchGuideId: '',
+    };
+  }
+
+  return {
+    productModelId: product.productModel?._id || '',
+    serialNumber: product.serialNumber || '',
+    inventoryNumber: product.type === 'PURCHASED' ? product.inventoryNumber || '' : '',
+    rentalId: product.type === 'RENTAL' ? product.rentalId || '' : '',
+    dispatchGuideId: product.dispatchGuide?._id || '',
+  };
+}
+
+function ProductEditForm({
+  product,
+  dispatchGuides,
+  productModels,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  onReloadDispatchGuides,
+  onReloadProductModels,
+  loadingDispatchGuides,
+  loadingProductModels,
+  guidesError,
+  modelsError,
+}) {
+  const [values, setValues] = useState(buildInitialState(product));
+  const [error, setError] = useState('');
+
+  const availableGuides = useMemo(() => {
+    const items = new Map();
+
+    if (product?.dispatchGuide) {
+      items.set(product.dispatchGuide._id, product.dispatchGuide);
+    }
+
+    dispatchGuides.forEach((guide) => {
+      if (!items.has(guide._id)) {
+        items.set(guide._id, guide);
+      }
+    });
+
+    return Array.from(items.values());
+  }, [dispatchGuides, product?.dispatchGuide]);
+
+  const availableModels = useMemo(() => {
+    const items = new Map();
+
+    if (product?.productModel) {
+      items.set(product.productModel._id, product.productModel);
+    }
+
+    productModels.forEach((model) => {
+      if (!items.has(model._id)) {
+        items.set(model._id, model);
+      }
+    });
+
+    return Array.from(items.values());
+  }, [productModels, product?.productModel]);
+
+  const selectedModel = useMemo(
+    () => availableModels.find((model) => model._id === values.productModelId) || null,
+    [availableModels, values.productModelId]
+  );
+
+  const hasDispatchGuides = availableGuides.length > 0;
+  const hasProductModels = availableModels.length > 0;
+
+  useEffect(() => {
+    setValues(buildInitialState(product));
+    setError('');
+  }, [product?._id]);
+
+  useEffect(() => {
+    setValues((prev) => {
+      if (!hasDispatchGuides) {
+        if (!prev.dispatchGuideId) {
+          return prev;
+        }
+        return { ...prev, dispatchGuideId: '' };
+      }
+
+      if (prev.dispatchGuideId && availableGuides.some((guide) => guide._id === prev.dispatchGuideId)) {
+        return prev;
+      }
+
+      return { ...prev, dispatchGuideId: availableGuides[0]._id };
+    });
+  }, [availableGuides, hasDispatchGuides]);
+
+  useEffect(() => {
+    setValues((prev) => {
+      if (!hasProductModels) {
+        if (!prev.productModelId) {
+          return prev;
+        }
+        return { ...prev, productModelId: '' };
+      }
+
+      if (prev.productModelId && availableModels.some((model) => model._id === prev.productModelId)) {
+        return prev;
+      }
+
+      return { ...prev, productModelId: availableModels[0]._id };
+    });
+  }, [availableModels, hasProductModels]);
+
+  if (!product) {
+    return null;
+  }
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+
+    if (!values.productModelId) {
+      setError('Selecciona el modelo de producto.');
+      return;
+    }
+
+    if (product.type === 'RENTAL' && !values.rentalId) {
+      setError('Debes ingresar el ID de arriendo.');
+      return;
+    }
+
+    if (!values.dispatchGuideId) {
+      setError('Selecciona la guía de despacho correspondiente al ingreso.');
+      return;
+    }
+
+    try {
+      await onSubmit({
+        productModelId: values.productModelId,
+        serialNumber: values.serialNumber,
+        inventoryNumber: product.type === 'PURCHASED' ? values.inventoryNumber : undefined,
+        rentalId: product.type === 'RENTAL' ? values.rentalId : undefined,
+        dispatchGuideId: values.dispatchGuideId,
+      });
+    } catch (submitError) {
+      setError(submitError.message || 'No se pudo actualizar el producto.');
+    }
+  };
+
+  return (
+    <form className="card" onSubmit={handleSubmit}>
+      <div className="card-header">
+        <div>
+          <h3>Editar producto</h3>
+          <p className="muted">
+            Actualiza los datos originales del producto seleccionado. El tipo de registro no puede modificarse.
+          </p>
+        </div>
+        <div className="section-actions">
+          <button
+            type="button"
+            className="secondary"
+            onClick={onReloadProductModels}
+            disabled={loadingProductModels}
+          >
+            {loadingProductModels ? 'Actualizando...' : 'Actualizar modelos'}
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={onReloadDispatchGuides}
+            disabled={loadingDispatchGuides}
+          >
+            {loadingDispatchGuides ? 'Actualizando...' : 'Actualizar guías'}
+          </button>
+        </div>
+      </div>
+
+      {modelsError && (
+        <p className="error" role="alert">
+          <strong>Error:</strong> {modelsError}
+        </p>
+      )}
+      {guidesError && (
+        <p className="error" role="alert">
+          <strong>Error:</strong> {guidesError}
+        </p>
+      )}
+
+      <div className="form-grid">
+        <label className="full-width">
+          Modelo de producto
+          <select
+            name="productModelId"
+            value={values.productModelId}
+            onChange={handleChange}
+            required
+            disabled={!hasProductModels}
+          >
+            {availableModels.map((model) => (
+              <option key={model._id} value={model._id}>
+                {model.name} — {model.partNumber}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {selectedModel?.description && (
+          <div className="full-width muted small-text">
+            <strong>Descripción:</strong> {selectedModel.description}
+          </div>
+        )}
+
+        <div>
+          <strong>Tipo:</strong> {product.type === 'PURCHASED' ? 'Compra' : 'Arriendo'}
+        </div>
+
+        <label>
+          N° de serie
+          <input name="serialNumber" value={values.serialNumber} onChange={handleChange} required />
+        </label>
+
+        {product.type === 'PURCHASED' && (
+          <label>
+            N° de inventario (opcional)
+            <input name="inventoryNumber" value={values.inventoryNumber} onChange={handleChange} />
+          </label>
+        )}
+
+        {product.type === 'RENTAL' && (
+          <label>
+            ID de arriendo
+            <input name="rentalId" value={values.rentalId} onChange={handleChange} required />
+          </label>
+        )}
+
+        <label>
+          Guía de despacho
+          <select
+            name="dispatchGuideId"
+            value={values.dispatchGuideId}
+            onChange={handleChange}
+            required
+            disabled={!hasDispatchGuides}
+          >
+            {availableGuides.map((guide) => (
+              <option key={guide._id} value={guide._id}>
+                {guide.guideNumber} — {new Date(guide.dispatchDate).toLocaleDateString('es-CL')}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="section-actions">
+        <button type="button" className="secondary" onClick={onCancel} disabled={isSubmitting}>
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          className="primary"
+          disabled={
+            isSubmitting || !hasDispatchGuides || !hasProductModels
+          }
+        >
+          {isSubmitting ? 'Guardando...' : 'Guardar cambios'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+ProductEditForm.defaultProps = {
+  dispatchGuides: [],
+  productModels: [],
+  isSubmitting: false,
+  onReloadDispatchGuides: () => {},
+  onReloadProductModels: () => {},
+  loadingDispatchGuides: false,
+  loadingProductModels: false,
+  guidesError: '',
+  modelsError: '',
+};
+
+export default ProductEditForm;

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import ProductEditForm from '../components/ProductEditForm';
 import ProductTable from '../components/ProductTable';
 import { useAuth } from '../hooks/useAuth';
 import { getProductStatusBadge, getProductStatusLabel } from '../utils/productStatus';
@@ -30,6 +31,14 @@ function InventoryPage() {
   const [statusFilter, setStatusFilter] = useState('ALL');
   const [deleting, setDeleting] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [editing, setEditing] = useState(false);
+  const [updatingProduct, setUpdatingProduct] = useState(false);
+  const [dispatchGuides, setDispatchGuides] = useState([]);
+  const [loadingGuides, setLoadingGuides] = useState(false);
+  const [guidesError, setGuidesError] = useState('');
+  const [productModels, setProductModels] = useState([]);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [modelsError, setModelsError] = useState('');
 
   const canManage = hasRole('ADMIN', 'MANAGER');
 
@@ -49,6 +58,49 @@ function InventoryPage() {
   useEffect(() => {
     loadProducts();
   }, [loadProducts]);
+
+  const loadDispatchGuides = useCallback(async () => {
+    if (!canManage) {
+      return;
+    }
+
+    setLoadingGuides(true);
+    setGuidesError('');
+    try {
+      const guides = await request('/dispatch-guides');
+      setDispatchGuides(guides);
+    } catch (err) {
+      setGuidesError(err.message || 'No se pudieron obtener las guías de despacho.');
+      setDispatchGuides([]);
+    } finally {
+      setLoadingGuides(false);
+    }
+  }, [canManage, request]);
+
+  const loadProductModels = useCallback(async () => {
+    if (!canManage) {
+      return;
+    }
+
+    setLoadingModels(true);
+    setModelsError('');
+    try {
+      const models = await request('/product-models');
+      setProductModels(models);
+    } catch (err) {
+      setModelsError(err.message || 'No se pudieron obtener los modelos de producto.');
+      setProductModels([]);
+    } finally {
+      setLoadingModels(false);
+    }
+  }, [canManage, request]);
+
+  useEffect(() => {
+    if (canManage) {
+      loadDispatchGuides();
+      loadProductModels();
+    }
+  }, [canManage, loadDispatchGuides, loadProductModels]);
 
   const filteredProducts = useMemo(
     () => filterProductsBySearch(products, searchTerm, { status: statusFilter }),
@@ -72,6 +124,18 @@ function InventoryPage() {
     [filteredProducts, selectedProductId]
   );
 
+  useEffect(() => {
+    if (!selectedProduct) {
+      setEditing(false);
+    }
+  }, [selectedProduct]);
+
+  useEffect(() => {
+    if (!selectedProductId) {
+      setEditing(false);
+    }
+  }, [selectedProductId]);
+
   const normalizedSearch = useMemo(() => normalizeSearchTerm(searchTerm), [searchTerm]);
 
   const selectedProductName = selectedProduct?.productModel?.name || selectedProduct?.name;
@@ -87,6 +151,41 @@ function InventoryPage() {
   const handleSearchChange = (event) => {
     setSearchTerm(event.target.value);
   };
+
+  const handleStartEdit = () => {
+    if (!selectedProduct || !canManage) {
+      return;
+    }
+    setEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setEditing(false);
+  };
+
+  const handleUpdateProduct = useCallback(
+    async (payload) => {
+      if (!canManage || !selectedProductId) {
+        return;
+      }
+
+      setUpdatingProduct(true);
+      try {
+        await request(`/products/${selectedProductId}`, {
+          method: 'PUT',
+          data: payload,
+        });
+        await loadProducts();
+        window.alert('Producto actualizado correctamente.');
+        setEditing(false);
+      } catch (err) {
+        throw err;
+      } finally {
+        setUpdatingProduct(false);
+      }
+    },
+    [canManage, selectedProductId, request, loadProducts]
+  );
 
   const handleDeleteProduct = useCallback(async () => {
     if (!selectedProduct || !canManage) {
@@ -163,114 +262,134 @@ function InventoryPage() {
           selectedProductId={selectedProductId}
           isFiltered={Boolean(normalizedSearch)}
         />
-        <div className="card">
-          <div className="card-header">
-            <h3>Detalle del producto</h3>
-            <p className="muted">
-              {selectedProduct
-                ? `Registrado el ${new Date(selectedProduct.createdAt).toLocaleDateString('es-CL')}`
-                : 'Selecciona un producto para ver su detalle.'}
-            </p>
-          </div>
+        {editing && selectedProduct ? (
+          <ProductEditForm
+            product={selectedProduct}
+            dispatchGuides={dispatchGuides}
+            productModels={productModels}
+            onSubmit={handleUpdateProduct}
+            onCancel={handleCancelEdit}
+            isSubmitting={updatingProduct}
+            onReloadDispatchGuides={loadDispatchGuides}
+            onReloadProductModels={loadProductModels}
+            loadingDispatchGuides={loadingGuides}
+            loadingProductModels={loadingModels}
+            guidesError={guidesError}
+            modelsError={modelsError}
+          />
+        ) : (
+          <div className="card">
+            <div className="card-header">
+              <h3>Detalle del producto</h3>
+              <p className="muted">
+                {selectedProduct
+                  ? `Registrado el ${new Date(selectedProduct.createdAt).toLocaleDateString('es-CL')}`
+                  : 'Selecciona un producto para ver su detalle.'}
+              </p>
+            </div>
 
-          {!selectedProduct && <p className="muted">No hay productos que coincidan con el filtro.</p>}
+            {!selectedProduct && <p className="muted">No hay productos que coincidan con el filtro.</p>}
 
-          {selectedProduct && (
-            <>
-              <div className="detail-grid">
-                <div>
-                  <strong>Nombre:</strong> {selectedProductName}
-                </div>
-                <div>
-                  <strong>Tipo:</strong> {formatType(selectedProduct.type)}
-                </div>
-                <div>
-                  <strong>N° serie:</strong> {selectedProduct.serialNumber}
-                </div>
-                <div>
-                  <strong>N° parte:</strong> {selectedProductPartNumber}
-                </div>
-                {selectedProduct.type === 'PURCHASED' ? (
+            {selectedProduct && (
+              <>
+                <div className="detail-grid">
                   <div>
-                    <strong>N° inventario:</strong> {selectedProduct.inventoryNumber || '—'}
+                    <strong>Nombre:</strong> {selectedProductName}
                   </div>
-                ) : (
                   <div>
-                    <strong>ID arriendo:</strong> {selectedProduct.rentalId}
+                    <strong>Tipo:</strong> {formatType(selectedProduct.type)}
                   </div>
-                )}
-                <div>
-                  <strong>Guía:</strong> {selectedProduct.dispatchGuide?.guideNumber || '—'}
-                </div>
-                {selectedProductDescription && (
-                  <div className="full-row">
-                    <strong>Descripción:</strong> {selectedProductDescription}
+                  <div>
+                    <strong>N° serie:</strong> {selectedProduct.serialNumber}
                   </div>
-                )}
-                <div className="full-row">
-                  <strong>Estado:</strong>{' '}
-                  <span className={getProductStatusBadge(selectedProduct.status)}>
-                    {getProductStatusLabel(selectedProduct.status)}
-                  </span>
-                </div>
-              </div>
-
-              {selectedProduct.status === 'ASSIGNED' && selectedProduct.currentAssignment && (
-                <div className="assignment-box">
-                  <p>
-                    <strong>{selectedProduct.currentAssignment.assignedTo}</strong>
-                  </p>
-                  {selectedProduct.currentAssignment.assignedEmail && (
-                    <p className="muted small-text">
-                      {selectedProduct.currentAssignment.assignedEmail}
-                    </p>
+                  <div>
+                    <strong>N° parte:</strong> {selectedProductPartNumber}
+                  </div>
+                  {selectedProduct.type === 'PURCHASED' ? (
+                    <div>
+                      <strong>N° inventario:</strong> {selectedProduct.inventoryNumber || '—'}
+                    </div>
+                  ) : (
+                    <div>
+                      <strong>ID arriendo:</strong> {selectedProduct.rentalId}
+                    </div>
                   )}
-                  <p className="muted">
-                    Ubicación: {selectedProduct.currentAssignment.location} ·{' '}
-                    {new Date(
-                      selectedProduct.currentAssignment.assignmentDate
-                    ).toLocaleString('es-CL')}
-                  </p>
+                  <div>
+                    <strong>Guía:</strong> {selectedProduct.dispatchGuide?.guideNumber || '—'}
+                  </div>
+                  {selectedProductDescription && (
+                    <div className="full-row">
+                      <strong>Descripción:</strong> {selectedProductDescription}
+                    </div>
+                  )}
+                  <div className="full-row">
+                    <strong>Estado:</strong>{' '}
+                    <span className={getProductStatusBadge(selectedProduct.status)}>
+                      {getProductStatusLabel(selectedProduct.status)}
+                    </span>
+                  </div>
                 </div>
-              )}
 
-              {selectedProduct.status === 'DECOMMISSIONED' && (
-                <div className="assignment-box">
-                  <p>
-                    <strong>Motivo de baja:</strong> {selectedProduct.decommissionReason}
-                  </p>
-                  <p className="muted">
-                    Registrado el{' '}
-                    {selectedProduct.decommissionedAt
-                      ? new Date(selectedProduct.decommissionedAt).toLocaleString('es-CL')
-                      : '—'}
-                    {selectedProduct.decommissionedBy?.name
-                      ? ` · Por ${selectedProduct.decommissionedBy.name}`
-                      : ''}
-                  </p>
-                </div>
-              )}
+                {selectedProduct.status === 'ASSIGNED' && selectedProduct.currentAssignment && (
+                  <div className="assignment-box">
+                    <p>
+                      <strong>{selectedProduct.currentAssignment.assignedTo}</strong>
+                    </p>
+                    {selectedProduct.currentAssignment.assignedEmail && (
+                      <p className="muted small-text">
+                        {selectedProduct.currentAssignment.assignedEmail}
+                      </p>
+                    )}
+                    <p className="muted">
+                      Ubicación: {selectedProduct.currentAssignment.location} ·{' '}
+                      {new Date(
+                        selectedProduct.currentAssignment.assignmentDate
+                      ).toLocaleString('es-CL')}
+                    </p>
+                  </div>
+                )}
 
-              {canManage && (
-                <div className="section-actions">
-                  <button
-                    type="button"
-                    className="danger"
-                    onClick={handleDeleteProduct}
-                    disabled={deleting || selectedProduct.status === 'ASSIGNED'}
-                  >
-                    {deleting ? 'Eliminando...' : 'Eliminar producto'}
-                  </button>
-                </div>
-              )}
-              {canManage && selectedProduct.status === 'ASSIGNED' && (
-                <p className="muted small-text">
-                  Debes liberar la asignación antes de eliminar el producto.
-                </p>
-              )}
-            </>
-          )}
-        </div>
+                {selectedProduct.status === 'DECOMMISSIONED' && (
+                  <div className="assignment-box">
+                    <p>
+                      <strong>Motivo de baja:</strong> {selectedProduct.decommissionReason}
+                    </p>
+                    <p className="muted">
+                      Registrado el{' '}
+                      {selectedProduct.decommissionedAt
+                        ? new Date(selectedProduct.decommissionedAt).toLocaleString('es-CL')
+                        : '—'}
+                      {selectedProduct.decommissionedBy?.name
+                        ? ` · Por ${selectedProduct.decommissionedBy.name}`
+                        : ''}
+                    </p>
+                  </div>
+                )}
+
+                {canManage && (
+                  <div className="section-actions">
+                    <button type="button" className="secondary" onClick={handleStartEdit}>
+                      Editar producto
+                    </button>
+                    <button
+                      type="button"
+                      className="danger"
+                      onClick={handleDeleteProduct}
+                      disabled={deleting || selectedProduct.status === 'ASSIGNED'}
+                    >
+                      {deleting ? 'Eliminando...' : 'Eliminar producto'}
+                    </button>
+                  </div>
+                )}
+                {canManage && selectedProduct.status === 'ASSIGNED' && (
+                  <p className="muted small-text">
+                    Debes liberar la asignación antes de eliminar el producto.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a dedicated ProductEditForm component that pre-fills existing data, validates required fields, and lets users refresh guides or models while editing
- extend the inventory page with data-loading helpers, an edit toggle, and integration of the new form alongside the existing product detail card
- refresh product data after updates and keep managers informed with success alerts and disabled states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d68c5cf74c8321852bf730eafb9bba