### PR TITLE
Permitir ingreso masivo de productos por serie

### DIFF
--- a/backend/src/routes/productRoutes.js
+++ b/backend/src/routes/productRoutes.js
@@ -11,6 +11,13 @@ router.post(
   productController.createProduct
 );
 
+router.post(
+  '/bulk',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  productController.createProductsBulk
+);
+
 router.get('/', authenticate, productController.listProducts);
 router.get('/stock', authenticate, productController.getStockSummary);
 router.get('/:id', authenticate, productController.getProduct);


### PR DESCRIPTION
## Summary
- add a backend endpoint to registrar múltiples productos asociados a una guía desde una sola carga
- expone la nueva ruta `/products/bulk` y mejora el alta individual al detectar duplicados
- actualiza el formulario del frontend para permitir pegar varias series y enviar la solicitud masiva

## Testing
- npm test (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_b_68d690094e5483219cdab04bc0478917