### PR TITLE
Add external decommission act records management

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,6 +6,7 @@ const path = require('path');
 const authRoutes = require('./routes/authRoutes');
 const productRoutes = require('./routes/productRoutes');
 const dispatchGuideRoutes = require('./routes/dispatchGuideRoutes');
+const externalDecommissionActRoutes = require('./routes/externalDecommissionActRoutes');
 const activeDirectoryRoutes = require('./routes/activeDirectoryRoutes');
 const productModelRoutes = require('./routes/productModelRoutes');
 const userRoutes = require('./routes/userRoutes');
@@ -28,6 +29,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/products', productRoutes);
 app.use('/api/product-models', productModelRoutes);
 app.use('/api/dispatch-guides', dispatchGuideRoutes);
+app.use('/api/external-decommission-acts', externalDecommissionActRoutes);
 app.use('/api/ad', activeDirectoryRoutes);
 app.use('/api/users', userRoutes);
 

--- a/backend/src/controllers/externalDecommissionActController.js
+++ b/backend/src/controllers/externalDecommissionActController.js
@@ -1,0 +1,105 @@
+const path = require('path');
+const fs = require('fs');
+const mongoose = require('mongoose');
+const ExternalDecommissionAct = require('../models/ExternalDecommissionAct');
+
+exports.createExternalDecommissionAct = async (req, res) => {
+  try {
+    const { inventoryManager, productName, serialNumber, operationalUnit, recordDate } = req.body;
+    const file = req.file;
+
+    if (!inventoryManager || !productName || !operationalUnit || !recordDate) {
+      return res.status(400).json({
+        message: 'Encargado, producto, unidad operativa y fecha son obligatorios.',
+      });
+    }
+
+    if (!file) {
+      return res
+        .status(400)
+        .json({ message: 'Debe adjuntar el documento del acta de baja externa.' });
+    }
+
+    const parsedRecordDate = new Date(recordDate);
+    if (Number.isNaN(parsedRecordDate.getTime())) {
+      return res.status(400).json({ message: 'La fecha del acta no es válida.' });
+    }
+
+    const act = await ExternalDecommissionAct.create({
+      inventoryManager,
+      productName,
+      serialNumber: serialNumber || '',
+      operationalUnit,
+      recordDate: parsedRecordDate,
+      fileName: file.originalname,
+      storedFileName: file.filename,
+      fileSize: file.size,
+      mimeType: file.mimetype,
+      uploadedBy: req.user._id,
+    });
+
+    res.status(201).json(act);
+  } catch (error) {
+    console.error('createExternalDecommissionAct error', error);
+    res.status(500).json({ message: 'No se pudo registrar el acta de baja externa.' });
+  }
+};
+
+exports.listExternalDecommissionActs = async (req, res) => {
+  try {
+    const acts = await ExternalDecommissionAct.find()
+      .populate('uploadedBy', 'name email role')
+      .sort({ recordDate: -1, createdAt: -1 });
+    res.json(acts);
+  } catch (error) {
+    console.error('listExternalDecommissionActs error', error);
+    res.status(500).json({ message: 'No se pudieron obtener las actas de bajas externas.' });
+  }
+};
+
+exports.getExternalDecommissionAct = async (req, res) => {
+  try {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Identificador inválido.' });
+    }
+
+    const act = await ExternalDecommissionAct.findById(req.params.id).populate(
+      'uploadedBy',
+      'name email role'
+    );
+    if (!act) {
+      return res.status(404).json({ message: 'Acta de baja externa no encontrada.' });
+    }
+
+    res.json(act);
+  } catch (error) {
+    console.error('getExternalDecommissionAct error', error);
+    res.status(500).json({ message: 'No se pudo obtener el acta de baja externa.' });
+  }
+};
+
+exports.downloadExternalDecommissionAct = async (req, res) => {
+  try {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ message: 'Identificador inválido.' });
+    }
+
+    const act = await ExternalDecommissionAct.findById(req.params.id);
+    if (!act) {
+      return res.status(404).json({ message: 'Acta de baja externa no encontrada.' });
+    }
+
+    const normalizedPath = path.normalize(
+      path.join(__dirname, '..', '..', 'uploads', act.storedFileName)
+    );
+
+    if (!fs.existsSync(normalizedPath)) {
+      return res.status(404).json({ message: 'Archivo no encontrado en el servidor.' });
+    }
+
+    res.download(normalizedPath, act.fileName);
+  } catch (error) {
+    console.error('downloadExternalDecommissionAct error', error);
+    res.status(500).json({ message: 'No se pudo descargar el acta de baja externa.' });
+  }
+};

--- a/backend/src/models/ExternalDecommissionAct.js
+++ b/backend/src/models/ExternalDecommissionAct.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const externalDecommissionActSchema = new Schema(
+  {
+    inventoryManager: { type: String, required: true, trim: true },
+    productName: { type: String, required: true, trim: true },
+    serialNumber: { type: String, trim: true },
+    operationalUnit: { type: String, required: true, trim: true },
+    recordDate: { type: Date, required: true },
+    fileName: { type: String, required: true },
+    storedFileName: { type: String, required: true },
+    fileSize: { type: Number },
+    mimeType: { type: String },
+    uploadedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+externalDecommissionActSchema.index({ recordDate: -1 });
+externalDecommissionActSchema.index({ inventoryManager: 1, productName: 1 });
+
+module.exports = mongoose.model('ExternalDecommissionAct', externalDecommissionActSchema);

--- a/backend/src/routes/externalDecommissionActRoutes.js
+++ b/backend/src/routes/externalDecommissionActRoutes.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const { authenticate, authorizeRoles } = require('../middleware/auth');
+const controller = require('../controllers/externalDecommissionActController');
+
+const uploadPath = path.join(__dirname, '..', '..', 'uploads');
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    fs.mkdirSync(uploadPath, { recursive: true });
+    cb(null, uploadPath);
+  },
+  filename: (req, file, cb) => {
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const sanitizedOriginal = file.originalname.replace(/[^a-zA-Z0-9\.\-_]/g, '_');
+    cb(null, `${uniqueSuffix}-${sanitizedOriginal}`);
+  },
+});
+
+const upload = multer({ storage });
+
+const router = express.Router();
+
+router.post(
+  '/',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  upload.single('actFile'),
+  controller.createExternalDecommissionAct
+);
+
+router.get(
+  '/',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  controller.listExternalDecommissionActs
+);
+
+router.get(
+  '/:id',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  controller.getExternalDecommissionAct
+);
+
+router.get(
+  '/:id/download',
+  authenticate,
+  authorizeRoles('ADMIN', 'MANAGER'),
+  controller.downloadExternalDecommissionAct
+);
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import ProductDecommissionPage from './pages/ProductDecommissionPage';
 import StockConsultPage from './pages/StockConsultPage';
 import ProductCatalogPage from './pages/ProductCatalogPage';
 import AccountManagementPage from './pages/AccountManagementPage';
+import ExternalDecommissionActsPage from './pages/ExternalDecommissionActsPage';
 
 function App() {
   const { isAuthenticated } = useAuth();
@@ -36,6 +37,7 @@ function App() {
         <Route path="productos/catalogo" element={<ProductCatalogPage />} />
         <Route path="guias" element={<DispatchGuidesPage />} />
         <Route path="bajas" element={<ProductDecommissionPage />} />
+        <Route path="bajas/externas" element={<ExternalDecommissionActsPage />} />
         <Route path="administracion/cuentas" element={<AccountManagementPage />} />
       </Route>
       <Route

--- a/frontend/src/components/ExternalDecommissionActsManager.jsx
+++ b/frontend/src/components/ExternalDecommissionActsManager.jsx
@@ -1,0 +1,168 @@
+import { useRef, useState } from 'react';
+
+const initialState = {
+  inventoryManager: '',
+  productName: '',
+  serialNumber: '',
+  operationalUnit: '',
+  recordDate: '',
+};
+
+function ExternalDecommissionActsManager({
+  acts,
+  onUpload,
+  onRefresh,
+  onDownload,
+  isUploading,
+  isFiltered = false,
+}) {
+  const [values, setValues] = useState(initialState);
+  const [error, setError] = useState('');
+  const fileInputRef = useRef(null);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+
+    if (!fileInputRef.current?.files?.length) {
+      setError('Debes adjuntar el documento del acta.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('inventoryManager', values.inventoryManager);
+    formData.append('productName', values.productName);
+    formData.append('serialNumber', values.serialNumber);
+    formData.append('operationalUnit', values.operationalUnit);
+    formData.append('recordDate', values.recordDate);
+    formData.append('actFile', fileInputRef.current.files[0]);
+
+    try {
+      await onUpload(formData);
+      setValues(initialState);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    } catch (uploadError) {
+      setError(uploadError.message || 'No se pudo registrar el acta.');
+    }
+  };
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h3>Actas de bajas externas</h3>
+        <p className="muted">
+          Registra los documentos de respaldo de bajas realizadas fuera del inventario del sistema.
+        </p>
+      </div>
+
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Encargado de inventario
+          <input
+            name="inventoryManager"
+            value={values.inventoryManager}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          Producto
+          <input name="productName" value={values.productName} onChange={handleChange} required />
+        </label>
+        <label>
+          Serie
+          <input name="serialNumber" value={values.serialNumber} onChange={handleChange} />
+        </label>
+        <label>
+          Unidad operativa
+          <input
+            name="operationalUnit"
+            value={values.operationalUnit}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          Fecha del acta
+          <input
+            type="date"
+            name="recordDate"
+            value={values.recordDate}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label className="full-width">
+          Documento del acta
+          <input type="file" ref={fileInputRef} accept="application/pdf,image/*" required />
+        </label>
+        {error && <p className="error">{error}</p>}
+        <div className="actions">
+          <button type="submit" className="primary" disabled={isUploading}>
+            {isUploading ? 'Guardando...' : 'Registrar acta'}
+          </button>
+          <button type="button" className="secondary" onClick={onRefresh}>
+            Actualizar listado
+          </button>
+        </div>
+      </form>
+
+      <div className="table-responsive">
+        <table className="data-table compact">
+          <thead>
+            <tr>
+              <th>Producto</th>
+              <th>Serie</th>
+              <th>Unidad operativa</th>
+              <th>Encargado</th>
+              <th>Fecha</th>
+              <th>Archivo</th>
+            </tr>
+          </thead>
+          <tbody>
+            {acts.length === 0 && (
+              <tr>
+                <td colSpan={6} className="muted">
+                  {isFiltered
+                    ? 'No hay actas que coincidan con la búsqueda.'
+                    : 'No hay actas registradas.'}
+                </td>
+              </tr>
+            )}
+            {acts.map((act) => (
+              <tr key={act._id}>
+                <td>{act.productName}</td>
+                <td>{act.serialNumber || '—'}</td>
+                <td>{act.operationalUnit}</td>
+                <td>{act.inventoryManager}</td>
+                <td>{new Date(act.recordDate).toLocaleDateString('es-CL')}</td>
+                <td>
+                  <button type="button" className="link" onClick={() => onDownload(act)}>
+                    Descargar
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+ExternalDecommissionActsManager.defaultProps = {
+  acts: [],
+  onRefresh: () => {},
+  onDownload: () => {},
+  isUploading: false,
+  isFiltered: false,
+};
+
+export default ExternalDecommissionActsManager;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { to: 'productos/catalogo', label: 'Catálogo de productos', requiresManage: true },
   { to: 'guias', label: 'Guías de despacho', requiresManage: true },
   { to: 'bajas', label: 'Bajas de inventario', requiresManage: true },
+  { to: 'bajas/externas', label: 'Actas de bajas externas', requiresManage: true },
   { to: 'administracion/cuentas', label: 'Administrar cuentas', requiresAdmin: true },
 ];
 

--- a/frontend/src/pages/ExternalDecommissionActsPage.jsx
+++ b/frontend/src/pages/ExternalDecommissionActsPage.jsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import ExternalDecommissionActsManager from '../components/ExternalDecommissionActsManager';
+import { getApiUrl } from '../api/client';
+import { useAuth } from '../hooks/useAuth';
+import { filterExternalDecommissionActs, normalizeSearchTerm } from '../utils/search';
+
+function ExternalDecommissionActsPage() {
+  const { request, token, hasRole } = useAuth();
+  const [acts, setActs] = useState([]);
+  const [loadingActs, setLoadingActs] = useState(false);
+  const [uploadingAct, setUploadingAct] = useState(false);
+  const [error, setError] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const canManage = hasRole('ADMIN', 'MANAGER');
+
+  const loadActs = useCallback(async () => {
+    setLoadingActs(true);
+    setError('');
+    try {
+      const data = await request('/external-decommission-acts');
+      setActs(data);
+    } catch (err) {
+      setError(err.message || 'No se pudieron obtener las actas de bajas externas.');
+      setActs([]);
+    } finally {
+      setLoadingActs(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    if (canManage) {
+      loadActs();
+    }
+  }, [loadActs, canManage]);
+
+  const handleUploadAct = useCallback(
+    async (formData) => {
+      setUploadingAct(true);
+      setError('');
+      try {
+        await request('/external-decommission-acts', {
+          method: 'POST',
+          formData,
+        });
+        await loadActs();
+        window.alert('Acta registrada correctamente.');
+      } catch (uploadError) {
+        setError(uploadError.message || 'No se pudo registrar el acta de baja externa.');
+        throw uploadError;
+      } finally {
+        setUploadingAct(false);
+      }
+    },
+    [request, loadActs]
+  );
+
+  const handleDownloadAct = useCallback(
+    async (act) => {
+      try {
+        const response = await fetch(
+          `${getApiUrl()}/external-decommission-acts/${act._id}/download`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error('No se pudo descargar el acta de baja externa.');
+        }
+
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = act.fileName || `${act.productName}.pdf`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        window.URL.revokeObjectURL(url);
+      } catch (downloadError) {
+        alert(downloadError.message || 'No se pudo descargar el acta de baja externa.');
+      }
+    },
+    [token]
+  );
+
+  const normalizedSearch = useMemo(() => normalizeSearchTerm(searchTerm), [searchTerm]);
+
+  const filteredActs = useMemo(
+    () => filterExternalDecommissionActs(acts, searchTerm),
+    [acts, searchTerm]
+  );
+
+  if (!canManage) {
+    return (
+      <section className="dashboard-section">
+        <div className="card">
+          <h2>Actas de bajas externas</h2>
+          <p className="muted">No tienes permisos para gestionar actas de bajas externas.</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-section">
+      <div className="section-header">
+        <div>
+          <h2>Actas de bajas externas</h2>
+          <p className="muted">
+            Registra y consulta los respaldos de bajas de equipos realizadas fuera del inventario.
+          </p>
+        </div>
+        <div className="section-actions">
+          <label className="inline-filter">
+            Buscar
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Producto, serie, unidad, encargado..."
+            />
+          </label>
+          <button
+            type="button"
+            className="secondary"
+            onClick={loadActs}
+            disabled={loadingActs}
+          >
+            {loadingActs ? 'Actualizando...' : 'Actualizar listado'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="card">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <ExternalDecommissionActsManager
+        acts={filteredActs}
+        onUpload={handleUploadAct}
+        onRefresh={loadActs}
+        onDownload={handleDownloadAct}
+        isUploading={uploadingAct}
+        isFiltered={Boolean(normalizedSearch)}
+      />
+    </section>
+  );
+}
+
+export default ExternalDecommissionActsPage;

--- a/frontend/src/utils/search.js
+++ b/frontend/src/utils/search.js
@@ -124,6 +124,31 @@ export function filterDispatchGuides(guides, term) {
   );
 }
 
+export function filterExternalDecommissionActs(acts, term) {
+  const normalizedTerm = normalizeSearchTerm(term);
+  const list = Array.isArray(acts) ? acts : [];
+
+  if (!normalizedTerm) {
+    return list;
+  }
+
+  return list.filter((act) =>
+    matchesAnyField(
+      [
+        act.inventoryManager,
+        act.productName,
+        act.serialNumber,
+        act.operationalUnit,
+        act.fileName,
+        act.uploadedBy?.name,
+        act.uploadedBy?.email,
+        toLocaleDate(act.recordDate),
+      ],
+      normalizedTerm
+    )
+  );
+}
+
 export function filterStockSummary(summary, term) {
   const normalizedTerm = normalizeSearchTerm(term);
   const list = Array.isArray(summary) ? summary : [];


### PR DESCRIPTION
## Summary
- add backend model, controller, and routes to store external decommission act metadata with uploaded files
- expose a new dashboard tab and page to register, list, filter, and download external decommission acts
- extend shared search utilities to support filtering external decommission act entries

## Testing
- npm --prefix frontend run build
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_b_68d6e876a014832180ec3e431a5520ab